### PR TITLE
chore: Remove relative path from webDriverPath

### DIFF
--- a/src/FlaUI.WebDriver.UITests/WebDriverFixture.cs
+++ b/src/FlaUI.WebDriver.UITests/WebDriverFixture.cs
@@ -19,10 +19,7 @@ namespace FlaUI.WebDriver.UITests
             string assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             Directory.SetCurrentDirectory(assemblyDir);
 
-            var assemblyConfigurationAttribute = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyConfigurationAttribute>();
-            var buildConfigurationName = assemblyConfigurationAttribute?.Configuration;
-
-            var webDriverPath = $"..\\..\\..\\..\\FlaUI.WebDriver\\bin\\{buildConfigurationName}\\FlaUI.WebDriver.exe";
+            string webDriverPath = Path.Combine(Directory.GetCurrentDirectory(), "FlaUI.WebDriver.exe");
             var webDriverArguments = $"--urls={WebDriverUrl}";
             var webDriverProcessStartInfo = new ProcessStartInfo(webDriverPath, webDriverArguments)
             {


### PR DESCRIPTION
Using relative paths in code can sometimes introduce issues, especially if the location of the files relative to the executing code changes. It can make the code less portable and more prone to breaking if moved to a different location or if the directory structure changes.
I for example had an issue running the project in debug mode since it was going to the release folder.
this change worked for me on both configurations: Debug and Release