### PR TITLE
Test run build on pushing tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,6 @@ name: build
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
Commit 14b22b24669991c611c7198ec7ace54fd4125e26 added creating a release on new tags, but the `build` job filter has no trigger on pushed tags.