### PR TITLE
Run build on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: build
 
 on:
   push:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: build
 
 on:
   push:
+    tags:
+      - "*"
+    branches:
+      - "main"
   pull_request:
 
 jobs:


### PR DESCRIPTION
Commit 71a5cebdb715313e4250f34587f786ff25af8c5e removed `pull_request` from the build workflow, but that should not have been done.