### PR TITLE
Avoid using relative path for WpfApplication

### DIFF
--- a/src/FlaUI.WebDriver.UITests/TestUtil/TestApplication.cs
+++ b/src/FlaUI.WebDriver.UITests/TestUtil/TestApplication.cs
@@ -1,9 +1,24 @@
 using System.IO;
+using System.Linq;
 
 namespace FlaUI.WebDriver.UITests.TestUtil
 {
     public static class TestApplication
     {
-        public static string FullPath => Path.GetFullPath("..\\..\\..\\..\\TestApplications\\WpfApplication\\bin\\Release\\WpfApplication.exe");
-    }
+
+        private static readonly string _currentDirectory = Directory.GetCurrentDirectory();
+        private static readonly string _solutionDirectory = FindSolutionDirectory(_currentDirectory);
+
+        private static string FindSolutionDirectory(string currentDirectory)
+        {
+            while (!Directory.GetFiles(currentDirectory, "*.sln").Any())
+            {
+                currentDirectory = Directory.GetParent(currentDirectory).FullName;
+            }
+            return currentDirectory;
+        }
+
+        public static string FullPath => Path.Combine(_solutionDirectory, "TestApplications", "WpfApplication", "bin", "Release", "WpfApplication.exe");
+    } 
+    
 }

--- a/src/FlaUI.WebDriver.UITests/TestUtil/TestApplication.cs
+++ b/src/FlaUI.WebDriver.UITests/TestUtil/TestApplication.cs
@@ -6,8 +6,8 @@ namespace FlaUI.WebDriver.UITests.TestUtil
     public static class TestApplication
     {
 
-        private static readonly string _currentDirectory = Directory.GetCurrentDirectory();
-        private static readonly string _solutionDirectory = FindSolutionDirectory(_currentDirectory);
+        private static readonly string s_currentDirectory = Directory.GetCurrentDirectory();
+        private static readonly string s_solutionDirectory = FindSolutionDirectory(s_currentDirectory);
 
         private static string FindSolutionDirectory(string currentDirectory)
         {
@@ -18,7 +18,7 @@ namespace FlaUI.WebDriver.UITests.TestUtil
             return currentDirectory;
         }
 
-        public static string FullPath => Path.Combine(_solutionDirectory, "TestApplications", "WpfApplication", "bin", "Release", "WpfApplication.exe");
+        public static string FullPath => Path.Combine(s_solutionDirectory, "TestApplications", "WpfApplication", "bin", "Release", "WpfApplication.exe");
     } 
     
 }


### PR DESCRIPTION
Added a more clever way to get the WpfApplication path by removing the usage of the relative path which is not recommended 