### PR TITLE
Implement Get Element Attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,22 @@ There is an interpretation to use the WebDriver specification to drive native au
 | tag name                           | Control type in Windows                                                                                                                |
 | attribute                          | [UI automation element property](https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-automation-element-propids) in Windows |
 
+### Element Attributes
+
+Attributes are mapped to UI automation element properties. Attributes without a period (`.`) are mapped to [Automation Element Properties](https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-automation-element-propids). For example to read the `UIA_ClassNamePropertyId` using Selenium WebDriver:
+
+```C#
+var element = driver.FindElement(By.Id("TextBox"));
+var value = element.GetDomAttribute("ClassName");
+```
+
+Attributes with a period are treated as [Control Pattern Properties](https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-control-pattern-propids) with the form `Pattern.Property`. For example to read the `UIA_ToggleToggleStatePropertyId` using Selenium WebDriver:
+
+```C#
+var element = driver.FindElement(By.Id("ToggleButton"));
+var value = element.GetDomAttribute("Toggle.ToggleState");
+```
+
 ## Next Steps
 
 Possible next steps for this project:

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ const result = driver.executeScript("powerShell", [{ command: `1+1` }]);
 | POST   | /session/{session id}/shadow/{shadow id}/element               | Find Element From Shadow Root  | N/A                |
 | POST   | /session/{session id}/shadow/{shadow id}/elements              | Find Elements From Shadow Root | N/A                |
 | GET    | /session/{session id}/element/{element id}/selected            | Is Element Selected            | :white_check_mark: |
-| GET    | /session/{session id}/element/{element id}/attribute/{name}    | Get Element Attribute          |                    |
+| GET    | /session/{session id}/element/{element id}/attribute/{name}    | Get Element Attribute          | :white_check_mark: |
 | GET    | /session/{session id}/element/{element id}/property/{name}     | Get Element Property           |                    |
 | GET    | /session/{session id}/element/{element id}/css/{property name} | Get Element CSS Value          | N/A                |
 | GET    | /session/{session id}/element/{element id}/text                | Get Element Text               | :white_check_mark: |

--- a/src/FlaUI.WebDriver.UITests/ElementTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ElementTests.cs
@@ -219,7 +219,7 @@ namespace FlaUI.WebDriver.UITests
             using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId("TextBox"));
 
-            var value = element.GetAttribute(attributeName);
+            var value = element.GetDomAttribute(attributeName);
 
             Assert.That(value, Is.EqualTo(expectedValue));
         }

--- a/src/FlaUI.WebDriver.UITests/ElementTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ElementTests.cs
@@ -213,7 +213,8 @@ namespace FlaUI.WebDriver.UITests
 
         [TestCase(["ClassName", "TextBox"])]
         [TestCase(["FrameworkId", "WPF"])]
-        public void GetAttribute_TextBox_ReturnsValue(string attributeName, string expectedValue)
+        [TestCase(["NonExistent", null])]
+        public void GetAttribute_TextBox_ReturnsValue(string attributeName, string? expectedValue)
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
             using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);

--- a/src/FlaUI.WebDriver.UITests/ElementTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ElementTests.cs
@@ -256,7 +256,7 @@ namespace FlaUI.WebDriver.UITests
         }
 
         [Test]
-        public void GetAttribute_Recognises_Pattern_Property()
+        public void GetAttribute_PatternProperty_ReturnsValue()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
             using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);

--- a/src/FlaUI.WebDriver.UITests/ElementTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ElementTests.cs
@@ -244,7 +244,7 @@ namespace FlaUI.WebDriver.UITests
         [TestCase(["ClassName", "TextBox"])]
         [TestCase(["FrameworkId", "WPF"])]
         [TestCase(["NonExistent", null])]
-        public void GetAttribute_TextBox_ReturnsValue(string attributeName, string? expectedValue)
+        public void GetAttribute_TextBox_ReturnsValue(string attributeName, string expectedValue)
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
             using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);

--- a/src/FlaUI.WebDriver.UITests/ElementTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ElementTests.cs
@@ -224,5 +224,25 @@ namespace FlaUI.WebDriver.UITests
 
             Assert.That(value, Is.EqualTo(expectedValue));
         }
+
+        [Test]
+        public void GetAttribute_Recognises_Pattern_Property()
+        {
+            var driverOptions = FlaUIDriverOptions.TestApp();
+            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            var element = driver.FindElement(ExtendedBy.AccessibilityId("SimpleCheckBox"));
+
+            var value = element.GetDomAttribute("Toggle.ToggleState");
+
+            Assert.That(value, Is.EqualTo("Off"));
+
+            element.Click();
+
+            value = element.GetDomAttribute("Toggle.ToggleState");
+
+            Assert.That(value, Is.EqualTo("On"));
+
+            element.Click();
+        }
     }
 }

--- a/src/FlaUI.WebDriver.UITests/ElementTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ElementTests.cs
@@ -211,12 +211,13 @@ namespace FlaUI.WebDriver.UITests
             Assert.That(activeElement.Text, Is.EqualTo("Invoked!"));
         }
 
-        [TestCase(["Name", "Label"])]
-        public void GetAttribute_Label_ReturnsValue(string attributeName, string expectedValue)
+        [TestCase(["ClassName", "TextBox"])]
+        [TestCase(["FrameworkId", "WPF"])]
+        public void GetAttribute_TextBox_ReturnsValue(string attributeName, string expectedValue)
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
             using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
-            var element = driver.FindElement(ExtendedBy.AccessibilityId("Label"));
+            var element = driver.FindElement(ExtendedBy.AccessibilityId("TextBox"));
 
             var value = element.GetAttribute(attributeName);
 

--- a/src/FlaUI.WebDriver.UITests/ElementTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ElementTests.cs
@@ -210,5 +210,17 @@ namespace FlaUI.WebDriver.UITests
 
             Assert.That(activeElement.Text, Is.EqualTo("Invoked!"));
         }
+
+        [TestCase(["Name", "Label"])]
+        public void GetAttribute_Label_ReturnsValue(string attributeName, string expectedValue)
+        {
+            var driverOptions = FlaUIDriverOptions.TestApp();
+            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            var element = driver.FindElement(ExtendedBy.AccessibilityId("Label"));
+
+            var value = element.GetAttribute(attributeName);
+
+            Assert.That(value, Is.EqualTo(expectedValue));
+        }
     }
 }

--- a/src/FlaUI.WebDriver/AutomationElementExtensions.cs
+++ b/src/FlaUI.WebDriver/AutomationElementExtensions.cs
@@ -1,0 +1,165 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using FlaUI.Core;
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Identifiers;
+using FlaUI.Core.Patterns;
+using FlaUI.Core.Patterns.Infrastructure;
+
+namespace FlaUI.WebDriver;
+
+public static class AutomationElementExtensions
+{
+    public static bool TryGetPattern(this AutomationElement element, string patternName, [NotNullWhen(true)] out IPattern? pattern)
+    {
+        static bool TryGet<T>(IAutomationPattern<T> pattern, out IPattern result) where T : IPattern
+        {
+            pattern.TryGetPattern(out var p);
+            result = p;
+            return p is not null;
+        }
+
+        if (patternName == nameof(element.Patterns.Annotation))
+        {
+            return TryGet(element.Patterns.Annotation, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.Dock))
+        {
+            return TryGet(element.Patterns.Dock, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.Drag))
+        {
+            return TryGet(element.Patterns.Drag, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.DropTarget))
+        {
+            return TryGet(element.Patterns.DropTarget, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.ExpandCollapse))
+        {
+            return TryGet(element.Patterns.ExpandCollapse, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.Grid))
+        {
+            return TryGet(element.Patterns.Grid, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.GridItem))
+        {
+            return TryGet(element.Patterns.GridItem, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.Invoke))
+        {
+            return TryGet(element.Patterns.Invoke, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.ItemContainer))
+        {
+            return TryGet(element.Patterns.ItemContainer, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.MultipleView))
+        {
+            return TryGet(element.Patterns.MultipleView, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.RangeValue))
+        {
+            return TryGet(element.Patterns.RangeValue, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.Scroll))
+        {
+            return TryGet(element.Patterns.Scroll, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.ScrollItem))
+        {
+            return TryGet(element.Patterns.ScrollItem, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.Selection))
+        {
+            return TryGet(element.Patterns.Selection, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.SelectionItem))
+        {
+            return TryGet(element.Patterns.SelectionItem, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.Spreadsheet))
+        {
+            return TryGet(element.Patterns.Spreadsheet, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.SpreadsheetItem))
+        {
+            return TryGet(element.Patterns.SpreadsheetItem, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.Styles))
+        {
+            return TryGet(element.Patterns.Styles, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.Table))
+        {
+            return TryGet(element.Patterns.Table, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.TableItem))
+        {
+            return TryGet(element.Patterns.TableItem, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.Text))
+        {
+            return TryGet(element.Patterns.Text, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.TextChild))
+        {
+            return TryGet(element.Patterns.TextChild, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.TextEdit))
+        {
+            return TryGet(element.Patterns.TextEdit, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.Text2))
+        {
+            return TryGet(element.Patterns.Text2, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.Toggle))
+        {
+            return TryGet(element.Patterns.Toggle, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.Transform))
+        {
+            return TryGet(element.Patterns.Transform, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.Value))
+        {
+            return TryGet(element.Patterns.Value, out pattern);
+        }
+        else if (patternName == nameof(element.Patterns.Window))
+        {
+            return TryGet(element.Patterns.Window, out pattern);
+        }
+
+        pattern = null;
+        return false;
+    }
+
+    public static bool TryGetProperty(this AutomationElement element, string propertyName, out object? value)
+    {
+        var library = element.FrameworkAutomationElement.PropertyIdLibrary;
+
+        // Not so crazy about using reflection here, but it seems it's the only way to get the property ID from a string?
+        if (library.GetType().GetProperty(propertyName) is { } propertyInfo &&
+            propertyInfo.GetValue(library) is PropertyId propertyId)
+        {
+            element.FrameworkAutomationElement.TryGetPropertyValue(propertyId, out value);
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    public static bool TryGetProperty(this IPattern pattern, string propertyName, out object? value)
+    {
+        if (pattern.GetType().GetProperty(propertyName) is { } propertyInfo)
+        {
+            value = propertyInfo.GetValue(pattern);
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+}

--- a/src/FlaUI.WebDriver/AutomationElementExtensions.cs
+++ b/src/FlaUI.WebDriver/AutomationElementExtensions.cs
@@ -1,134 +1,28 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using FlaUI.Core;
 using FlaUI.Core.AutomationElements;
 using FlaUI.Core.Identifiers;
-using FlaUI.Core.Patterns;
 using FlaUI.Core.Patterns.Infrastructure;
+using static FlaUI.Core.FrameworkAutomationElementBase;
 
 namespace FlaUI.WebDriver;
 
+/// <summary>
+/// Gets properties and patterns from an <see cref="AutomationElement"/>.
+/// </summary>
+/// <remarks>
+/// Not so crazy about using reflection here, but it seems it's the only way to query these objects by string?
+/// </remarks>
 public static class AutomationElementExtensions
 {
     public static bool TryGetPattern(this AutomationElement element, string patternName, [NotNullWhen(true)] out IPattern? pattern)
     {
-        static bool TryGet<T>(IAutomationPattern<T> pattern, out IPattern result) where T : IPattern
+        if (typeof(IFrameworkPatterns).GetProperty(patternName) is { } propertyInfo &&
+            propertyInfo.GetValue(element.Patterns) is { } patterns &&
+            patterns.GetType().GetProperty("PatternOrDefault") is { } patternPropertyInfo &&
+            patternPropertyInfo.GetValue(patterns) is IPattern patternValue)
         {
-            pattern.TryGetPattern(out var p);
-            result = p;
-            return p is not null;
-        }
-
-        if (patternName == nameof(element.Patterns.Annotation))
-        {
-            return TryGet(element.Patterns.Annotation, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.Dock))
-        {
-            return TryGet(element.Patterns.Dock, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.Drag))
-        {
-            return TryGet(element.Patterns.Drag, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.DropTarget))
-        {
-            return TryGet(element.Patterns.DropTarget, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.ExpandCollapse))
-        {
-            return TryGet(element.Patterns.ExpandCollapse, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.Grid))
-        {
-            return TryGet(element.Patterns.Grid, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.GridItem))
-        {
-            return TryGet(element.Patterns.GridItem, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.Invoke))
-        {
-            return TryGet(element.Patterns.Invoke, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.ItemContainer))
-        {
-            return TryGet(element.Patterns.ItemContainer, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.MultipleView))
-        {
-            return TryGet(element.Patterns.MultipleView, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.RangeValue))
-        {
-            return TryGet(element.Patterns.RangeValue, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.Scroll))
-        {
-            return TryGet(element.Patterns.Scroll, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.ScrollItem))
-        {
-            return TryGet(element.Patterns.ScrollItem, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.Selection))
-        {
-            return TryGet(element.Patterns.Selection, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.SelectionItem))
-        {
-            return TryGet(element.Patterns.SelectionItem, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.Spreadsheet))
-        {
-            return TryGet(element.Patterns.Spreadsheet, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.SpreadsheetItem))
-        {
-            return TryGet(element.Patterns.SpreadsheetItem, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.Styles))
-        {
-            return TryGet(element.Patterns.Styles, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.Table))
-        {
-            return TryGet(element.Patterns.Table, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.TableItem))
-        {
-            return TryGet(element.Patterns.TableItem, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.Text))
-        {
-            return TryGet(element.Patterns.Text, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.TextChild))
-        {
-            return TryGet(element.Patterns.TextChild, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.TextEdit))
-        {
-            return TryGet(element.Patterns.TextEdit, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.Text2))
-        {
-            return TryGet(element.Patterns.Text2, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.Toggle))
-        {
-            return TryGet(element.Patterns.Toggle, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.Transform))
-        {
-            return TryGet(element.Patterns.Transform, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.Value))
-        {
-            return TryGet(element.Patterns.Value, out pattern);
-        }
-        else if (patternName == nameof(element.Patterns.Window))
-        {
-            return TryGet(element.Patterns.Window, out pattern);
+            pattern = patternValue;
+            return true;
         }
 
         pattern = null;
@@ -139,7 +33,6 @@ public static class AutomationElementExtensions
     {
         var library = element.FrameworkAutomationElement.PropertyIdLibrary;
 
-        // Not so crazy about using reflection here, but it seems it's the only way to get the property ID from a string?
         if (library.GetType().GetProperty(propertyName) is { } propertyInfo &&
             propertyInfo.GetValue(library) is PropertyId propertyId)
         {

--- a/src/FlaUI.WebDriver/Controllers/ElementController.cs
+++ b/src/FlaUI.WebDriver/Controllers/ElementController.cs
@@ -1,6 +1,10 @@
-﻿using FlaUI.Core.AutomationElements;
+﻿using FlaUI.Core;
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Identifiers;
 using FlaUI.WebDriver.Models;
 using Microsoft.AspNetCore.Mvc;
+using System.Drawing;
+using System.Globalization;
 using System.Text;
 
 namespace FlaUI.WebDriver.Controllers
@@ -158,6 +162,24 @@ namespace FlaUI.WebDriver.Controllers
             element.AsTextBox().Text = elementSendKeysRequest.Text;
 
             return WebDriverResult.Success();
+        }
+
+        [HttpGet("{elementId}/attribute/{attributeId}")]
+        public async Task<ActionResult> GetAttribute([FromRoute] string sessionId, [FromRoute] string elementId, [FromRoute] string attributeId)
+        {
+            var session = GetSession(sessionId);
+            var element = GetElement(session, elementId);
+            var library = element.FrameworkAutomationElement.PropertyIdLibrary;
+            object? value = null;
+
+            // Not so crazy about using reflection here, but it seems it's the only way to get the property ID from a string?
+            if (library.GetType().GetProperty(attributeId) is { } propertyInfo &&
+                propertyInfo.GetValue(library) is PropertyId propertyId)
+            {
+                element.FrameworkAutomationElement.TryGetPropertyValue(propertyId, out value);
+            }
+
+            return await Task.FromResult(WebDriverResult.Success(value));
         }
 
         [HttpGet("{elementId}/rect")]

--- a/src/FlaUI.WebDriver/Controllers/ElementController.cs
+++ b/src/FlaUI.WebDriver/Controllers/ElementController.cs
@@ -1,11 +1,8 @@
-﻿using FlaUI.Core;
+﻿using System.Text;
 using FlaUI.Core.AutomationElements;
 using FlaUI.Core.Identifiers;
 using FlaUI.WebDriver.Models;
 using Microsoft.AspNetCore.Mvc;
-using System.Drawing;
-using System.Globalization;
-using System.Text;
 
 namespace FlaUI.WebDriver.Controllers
 {

--- a/src/FlaUI.WebDriver/Controllers/ElementController.cs
+++ b/src/FlaUI.WebDriver/Controllers/ElementController.cs
@@ -167,16 +167,25 @@ namespace FlaUI.WebDriver.Controllers
             var session = GetSession(sessionId);
             var element = GetElement(session, elementId);
             var library = element.FrameworkAutomationElement.PropertyIdLibrary;
+            var periodIndex = attributeId.IndexOf('.');
             object? value = null;
 
-            // Not so crazy about using reflection here, but it seems it's the only way to get the property ID from a string?
-            if (library.GetType().GetProperty(attributeId) is { } propertyInfo &&
-                propertyInfo.GetValue(library) is PropertyId propertyId)
+            if (periodIndex >= 0)
             {
-                element.FrameworkAutomationElement.TryGetPropertyValue(propertyId, out value);
+                var patternName = attributeId.Substring(0, periodIndex);
+                var propertyName = attributeId.Substring(periodIndex + 1);
+
+                if (element.TryGetPattern(patternName, out var pattern))
+                {
+                    pattern.TryGetProperty(propertyName, out value);
+                }
+            }
+            else
+            {
+                element.TryGetProperty(attributeId, out value);
             }
 
-            return await Task.FromResult(WebDriverResult.Success(value));
+            return await Task.FromResult(WebDriverResult.Success(value?.ToString()));
         }
 
         [HttpGet("{elementId}/rect")]


### PR DESCRIPTION
Implements `/session/{session id}/element/{element id}/attribute/{name}`.

Not so crazy about using reflection here, but it seems it's the only way to get the property ID from a string?

Fixes #25 

## TODO

- [x] Add test
- [x] Make test pass
- [x] Add support for `Pattern.Property` attributes as supported by WinAppDriver (e.g. https://github.com/microsoft/WinAppDriver/blob/master/Tests/WebDriverAPI/ElementAttribute.cs#L69)