### PR TITLE
Use Appium.WebDriver instead of Selenium.WebDriver for tests.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Use `dotnet build` to build.
 
 ## Testing
 
-Use `dotnet test` to run tests. At the moment the tests are end-to-end UI tests that use [Selenium.WebDriver](https://www.nuget.org/packages/Selenium.WebDriver) to operate a test application, running FlaUI.WebDriver.exe in the background, so they should be run on Windows.
+Use `dotnet test` to run tests. At the moment the tests are end-to-end UI tests that use [Appium.WebDriver](https://github.com/appium/dotnet-client) to operate a test application, running FlaUI.WebDriver.exe in the background, so they should be run on Windows.
 
 Add UI tests for every feature added and every bug fixed, and feel free to improve existing test coverage.
 

--- a/src/FlaUI.WebDriver.UITests/ActionsTest.cs
+++ b/src/FlaUI.WebDriver.UITests/ActionsTest.cs
@@ -1,21 +1,21 @@
 ﻿using FlaUI.WebDriver.UITests.TestUtil;
 using NUnit.Framework;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Interactions;
-using OpenQA.Selenium.Remote;
 
 namespace FlaUI.WebDriver.UITests
 {
     [TestFixture]
     public class ActionsTests
     {
-        private RemoteWebDriver _driver;
+        private WindowsDriver _driver;
 
         [SetUp]
         public void Setup()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            _driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            _driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
         }
 
         [TearDown]

--- a/src/FlaUI.WebDriver.UITests/ElementTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ElementTests.cs
@@ -1,6 +1,7 @@
 ﻿using FlaUI.WebDriver.UITests.TestUtil;
 using NUnit.Framework;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 using System;
 
@@ -13,7 +14,7 @@ namespace FlaUI.WebDriver.UITests
         public void GetText_Label_ReturnsRenderedText()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId("Label"));
 
             var text = element.Text;
@@ -25,7 +26,7 @@ namespace FlaUI.WebDriver.UITests
         public void GetText_TextBox_ReturnsTextBoxText()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId("TextBox"));
 
             var text = element.Text;
@@ -37,7 +38,7 @@ namespace FlaUI.WebDriver.UITests
         public void GetText_Button_ReturnsButtonText()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId("InvokableButton"));
 
             var text = element.Text;
@@ -49,7 +50,7 @@ namespace FlaUI.WebDriver.UITests
         public void Selected_NotCheckedCheckbox_ReturnsFalse()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId("SimpleCheckBox"));
 
             var selected = element.Selected;
@@ -61,7 +62,7 @@ namespace FlaUI.WebDriver.UITests
         public void Selected_CheckedCheckbox_ReturnsTrue()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId("SimpleCheckBox"));
             element.Click();
 
@@ -74,7 +75,7 @@ namespace FlaUI.WebDriver.UITests
         public void Selected_NotCheckedRadioButton_ReturnsFalse()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId("RadioButton1"));
 
             var selected = element.Selected;
@@ -86,7 +87,7 @@ namespace FlaUI.WebDriver.UITests
         public void Selected_CheckedRadioButton_ReturnsTrue()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId("RadioButton1"));
             element.Click();
 
@@ -99,7 +100,7 @@ namespace FlaUI.WebDriver.UITests
         public void SendKeys_Default_IsSupported()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId("TextBox"));
 
             element.SendKeys("Hello World!");
@@ -111,7 +112,7 @@ namespace FlaUI.WebDriver.UITests
         public void Clear_Default_IsSupported()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId("TextBox"));
 
             element.Clear();
@@ -123,7 +124,7 @@ namespace FlaUI.WebDriver.UITests
         public void Click_Default_IsSupported()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId("InvokableButton"));
 
             element.Click();
@@ -135,7 +136,7 @@ namespace FlaUI.WebDriver.UITests
         public void GetElementRect_Default_IsSupported()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId("EditableCombo"));
 
             var location = element.Location;
@@ -164,7 +165,7 @@ namespace FlaUI.WebDriver.UITests
         public void GetElementEnabled_Enabled_ReturnsTrue(string elementAccessibilityId)
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId(elementAccessibilityId));
 
             var enabled = element.Enabled;
@@ -188,7 +189,7 @@ namespace FlaUI.WebDriver.UITests
         public void GetElementEnabled_Disabled_ReturnsFalse(string elementAccessibilityId)
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             driver.FindElement(ExtendedBy.NonCssName("_Edit")).Click();
             driver.FindElement(ExtendedBy.NonCssName("Disable Form")).Click();
             var element = driver.FindElement(ExtendedBy.AccessibilityId(elementAccessibilityId));
@@ -202,7 +203,7 @@ namespace FlaUI.WebDriver.UITests
         public void ActiveElement_Default_IsSupported()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId("InvokableButton"));
             element.Click();
 

--- a/src/FlaUI.WebDriver.UITests/ExecuteTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ExecuteTests.cs
@@ -1,7 +1,7 @@
-﻿using FlaUI.WebDriver.UITests.TestUtil;
+﻿using System.Collections.Generic;
+using FlaUI.WebDriver.UITests.TestUtil;
 using NUnit.Framework;
-using OpenQA.Selenium.Remote;
-using System.Collections.Generic;
+using OpenQA.Selenium.Appium.Windows;
 
 namespace FlaUI.WebDriver.UITests
 {
@@ -12,7 +12,7 @@ namespace FlaUI.WebDriver.UITests
         public void ExecuteScript_PowerShellCommand_ReturnsResult()
         {
             var driverOptions = FlaUIDriverOptions.RootApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var executeScriptResult = driver.ExecuteScript("powerShell", new Dictionary<string,string> { ["command"] = "1+1" });
 

--- a/src/FlaUI.WebDriver.UITests/FindElementsTests.cs
+++ b/src/FlaUI.WebDriver.UITests/FindElementsTests.cs
@@ -1,8 +1,8 @@
+using System.Linq;
 using FlaUI.WebDriver.UITests.TestUtil;
 using NUnit.Framework;
 using OpenQA.Selenium;
-using OpenQA.Selenium.Remote;
-using System.Linq;
+using OpenQA.Selenium.Appium.Windows;
 
 namespace FlaUI.WebDriver.UITests
 {
@@ -12,7 +12,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElement_ByXPath_ReturnsElement()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var element = driver.FindElement(By.XPath("//Text"));
 
@@ -23,7 +23,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElement_ByAccessibilityId_ReturnsElement()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var element = driver.FindElement(ExtendedBy.AccessibilityId("TextBox"));
 
@@ -34,7 +34,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElement_ById_ReturnsElement()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var element = driver.FindElement(By.Id("TextBox"));
 
@@ -45,7 +45,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElement_ByName_ReturnsElement()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var element = driver.FindElement(By.Name("Test Label"));
 
@@ -56,7 +56,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElement_ByNativeName_ReturnsElement()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var element = driver.FindElement(ExtendedBy.NonCssName("Test Label"));
 
@@ -67,7 +67,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElement_ByNativeClassName_ReturnsElement()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var element = driver.FindElement(ExtendedBy.NonCssClassName("TextBlock"));
 
@@ -78,7 +78,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElement_ByClassName_ReturnsElement()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var element = driver.FindElement(By.ClassName("TextBlock"));
 
@@ -89,7 +89,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElement_ByLinkText_ReturnsElement()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var element = driver.FindElement(By.LinkText("Invoke me!"));
 
@@ -100,7 +100,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElement_ByPartialLinkText_ReturnsElement()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var element = driver.FindElement(By.PartialLinkText("Invoke"));
 
@@ -111,7 +111,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElement_ByTagName_ReturnsElement()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var element = driver.FindElement(By.TagName("Text"));
 
@@ -122,7 +122,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElement_NotExisting_TimesOut()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var findElement = () => driver.FindElement(ExtendedBy.AccessibilityId("NotExisting"));
 
@@ -133,7 +133,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElementFromElement_InsideElement_ReturnsElement()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var fromElement = driver.FindElement(By.TagName("Tab"));
 
             var foundElement = fromElement.FindElement(ExtendedBy.AccessibilityId("TextBox"));
@@ -145,7 +145,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElementFromElement_OutsideElement_TimesOut()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var fromElement = driver.FindElement(ExtendedBy.AccessibilityId("ListBox"));
 
             var findElement = () => fromElement.FindElement(ExtendedBy.AccessibilityId("TextBox"));
@@ -157,7 +157,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElementsFromElement_InsideElement_ReturnsElement()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var fromElement = driver.FindElement(By.TagName("Tab"));
 
             var foundElements = fromElement.FindElements(By.TagName("RadioButton"));
@@ -169,7 +169,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElementsFromElement_OutsideElement_TimesOut()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var fromElement = driver.FindElement(ExtendedBy.AccessibilityId("ListBox"));
 
             var findElements = () => fromElement.FindElements(ExtendedBy.AccessibilityId("TextBox"));
@@ -181,7 +181,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElements_Default_ReturnsElements()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var elements = driver.FindElements(By.TagName("RadioButton"));
 
@@ -192,7 +192,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElements_NotExisting_TimesOut()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var findElements = () => driver.FindElements(ExtendedBy.AccessibilityId("NotExisting"));
 
@@ -203,7 +203,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElement_InOtherWindow_TimesOut()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             OpenAndSwitchToAnotherWindow(driver);
 
             var findElement = () => driver.FindElement(ExtendedBy.AccessibilityId("TextBox"));
@@ -217,7 +217,7 @@ namespace FlaUI.WebDriver.UITests
         public void FindElements_InOtherWindow_TimesOut()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             OpenAndSwitchToAnotherWindow(driver);
 
             var findElements = () => driver.FindElements(ExtendedBy.AccessibilityId("TextBox"));
@@ -227,7 +227,7 @@ namespace FlaUI.WebDriver.UITests
             Assert.That(elementsInNewWindow, Has.Count.EqualTo(1));
         }
 
-        private static void OpenAndSwitchToAnotherWindow(RemoteWebDriver driver)
+        private static void OpenAndSwitchToAnotherWindow(WindowsDriver driver)
         {
             var initialWindowHandles = new[] { driver.CurrentWindowHandle };
             OpenAnotherWindow(driver);
@@ -236,7 +236,7 @@ namespace FlaUI.WebDriver.UITests
             driver.SwitchTo().Window(newWindowHandle);
         }
 
-        private static void OpenAnotherWindow(RemoteWebDriver driver)
+        private static void OpenAnotherWindow(WindowsDriver driver)
         {
             driver.FindElement(ExtendedBy.NonCssName("_File")).Click();
             driver.FindElement(ExtendedBy.NonCssName("Open Window 1")).Click();

--- a/src/FlaUI.WebDriver.UITests/FlaUI.WebDriver.UITests.csproj
+++ b/src/FlaUI.WebDriver.UITests/FlaUI.WebDriver.UITests.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Appium.WebDriver" Version="5.0.0-rc.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.15.0" />
     <PackageReference Include="coverlet.collector" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/FlaUI.WebDriver.UITests/TestUtil/FlaUIDriverOptions.cs
+++ b/src/FlaUI.WebDriver.UITests/TestUtil/FlaUIDriverOptions.cs
@@ -1,52 +1,48 @@
 ﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
 
 namespace FlaUI.WebDriver.UITests.TestUtil
 {
-    internal class FlaUIDriverOptions : DriverOptions
+    internal class FlaUIDriverOptions : AppiumOptions
     {
-        public override ICapabilities ToCapabilities()
-        {
-            return GenerateDesiredCapabilities(true);
-        }
+        public static FlaUIDriverOptions TestApp() => ForApp(TestApplication.FullPath);
 
-        public static FlaUIDriverOptions TestApp() => App(TestApplication.FullPath);
+        public static FlaUIDriverOptions RootApp() => ForApp("Root");
 
-        public static DriverOptions RootApp() => App("Root");
-
-        public static FlaUIDriverOptions App(string path)
+        public static FlaUIDriverOptions ForApp(string path)
         {
             var options = new FlaUIDriverOptions()
             {
+                App = path,
+                AutomationName = "FlaUI",
                 PlatformName = "Windows"
             };
-            options.AddAdditionalOption("appium:automationName", "FlaUI");
-            options.AddAdditionalOption("appium:app", path);
             return options;
         }
 
-        public static DriverOptions AppTopLevelWindow(string windowHandle)
+        public static FlaUIDriverOptions ForAppTopLevelWindow(string windowHandle)
         {
             var options = new FlaUIDriverOptions()
             {
+                AutomationName = "FlaUI",
                 PlatformName = "Windows"
             };
-            options.AddAdditionalOption("appium:automationName", "FlaUI");
-            options.AddAdditionalOption("appium:appTopLevelWindow", windowHandle);
+            options.AddAdditionalAppiumOption("appium:appTopLevelWindow", windowHandle);
             return options;
         }
 
-        public static DriverOptions AppTopLevelWindowTitleMatch(string match)
+        public static FlaUIDriverOptions ForAppTopLevelWindowTitleMatch(string match)
         {
             var options = new FlaUIDriverOptions()
             {
+                AutomationName = "FlaUI",
                 PlatformName = "Windows"
             };
-            options.AddAdditionalOption("appium:automationName", "FlaUI");
-            options.AddAdditionalOption("appium:appTopLevelWindowTitleMatch", match);
+            options.AddAdditionalAppiumOption("appium:appTopLevelWindowTitleMatch", match);
             return options;
         }
 
-        public static DriverOptions Empty()
+        public static FlaUIDriverOptions Empty()
         {
             return new FlaUIDriverOptions();
         }

--- a/src/FlaUI.WebDriver.UITests/TimeoutsTests.cs
+++ b/src/FlaUI.WebDriver.UITests/TimeoutsTests.cs
@@ -1,7 +1,7 @@
-﻿using FlaUI.WebDriver.UITests.TestUtil;
+﻿using System;
+using FlaUI.WebDriver.UITests.TestUtil;
 using NUnit.Framework;
-using OpenQA.Selenium.Remote;
-using System;
+using OpenQA.Selenium.Appium.Windows;
 
 namespace FlaUI.WebDriver.UITests
 {
@@ -12,7 +12,7 @@ namespace FlaUI.WebDriver.UITests
         public void SetTimeouts_Default_IsSupported()
         {
             var driverOptions = FlaUIDriverOptions.RootApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(3);
 
@@ -23,7 +23,7 @@ namespace FlaUI.WebDriver.UITests
         public void GetTimeouts_Default_ReturnsDefaultTimeouts()
         {
             var driverOptions = FlaUIDriverOptions.RootApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var timeouts = driver.Manage().Timeouts();
 

--- a/src/FlaUI.WebDriver.UITests/WindowTests.cs
+++ b/src/FlaUI.WebDriver.UITests/WindowTests.cs
@@ -1,8 +1,8 @@
-﻿using FlaUI.WebDriver.UITests.TestUtil;
+﻿using System.Linq;
+using FlaUI.WebDriver.UITests.TestUtil;
 using NUnit.Framework;
 using OpenQA.Selenium;
-using OpenQA.Selenium.Remote;
-using System.Linq;
+using OpenQA.Selenium.Appium.Windows;
 
 namespace FlaUI.WebDriver.UITests
 {
@@ -13,7 +13,7 @@ namespace FlaUI.WebDriver.UITests
         public void GetWindowRect_Default_IsSupported()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             var position = driver.Manage().Window.Position;
             var size = driver.Manage().Window.Size;
@@ -28,7 +28,7 @@ namespace FlaUI.WebDriver.UITests
         public void SetWindowRect_Position_IsSupported()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             driver.Manage().Window.Position = new System.Drawing.Point(100, 100);
 
@@ -41,7 +41,7 @@ namespace FlaUI.WebDriver.UITests
         public void SetWindowRect_Size_IsSupported()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             driver.Manage().Window.Size = new System.Drawing.Size(650, 650);
 
@@ -54,7 +54,7 @@ namespace FlaUI.WebDriver.UITests
         public void GetWindowHandle_AppOpensNewWindow_DoesNotSwitchToNewWindow()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var initialWindowHandle = driver.CurrentWindowHandle;
             OpenAnotherWindow(driver);
 
@@ -67,7 +67,7 @@ namespace FlaUI.WebDriver.UITests
         public void GetWindowHandle_WindowClosed_ReturnsNoSuchWindow()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             OpenAndSwitchToNewWindow(driver);
             driver.Close();
 
@@ -80,7 +80,7 @@ namespace FlaUI.WebDriver.UITests
         public void GetWindowHandles_Default_ReturnsUniqueHandlePerWindow()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var initialWindowHandle = driver.CurrentWindowHandle;
             OpenAnotherWindow(driver);
 
@@ -94,7 +94,7 @@ namespace FlaUI.WebDriver.UITests
         public void Close_Default_DoesNotChangeWindowHandle()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var initialWindowHandle = driver.CurrentWindowHandle;
             OpenAnotherWindow(driver);
 
@@ -108,7 +108,7 @@ namespace FlaUI.WebDriver.UITests
         public void Close_LastWindow_EndsSession()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
             driver.Close();
 
@@ -120,7 +120,7 @@ namespace FlaUI.WebDriver.UITests
         public void SwitchWindow_Default_SwitchesToWindow()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var initialWindowHandle = driver.CurrentWindowHandle;
             OpenAnotherWindow(driver);
             var newWindowHandle = driver.WindowHandles.Except(new[] { initialWindowHandle }).Single();
@@ -134,7 +134,7 @@ namespace FlaUI.WebDriver.UITests
         public void SwitchWindow_Default_MovesWindowToForeground()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            using var driver = new WindowsDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var initialWindowHandle = driver.CurrentWindowHandle;
             OpenAnotherWindow(driver);
 
@@ -146,7 +146,7 @@ namespace FlaUI.WebDriver.UITests
             Assert.That(element.Text, Is.EqualTo("Invoked!"));
         }
 
-        private static void OpenAndSwitchToNewWindow(RemoteWebDriver driver)
+        private static void OpenAndSwitchToNewWindow(WindowsDriver driver)
         {
             var initialWindowHandle = driver.CurrentWindowHandle;
             OpenAnotherWindow(driver);
@@ -154,7 +154,7 @@ namespace FlaUI.WebDriver.UITests
             driver.SwitchTo().Window(newWindowHandle);
         }
 
-        private static void OpenAnotherWindow(RemoteWebDriver driver)
+        private static void OpenAnotherWindow(WindowsDriver driver)
         {
             driver.FindElement(ExtendedBy.NonCssName("_File")).Click();
             driver.FindElement(ExtendedBy.NonCssName("Open Window 1")).Click();


### PR DESCRIPTION
Note sure if this is desired or not, but this allows the `Get Element Attribute` test in #27 to work. Seems like `Selenium.WebDriver` tries to execute a script in order to read attributes?