### PR TITLE
Support `origin` property in actions.

### DIFF
--- a/src/FlaUI.WebDriver.UITests/ActionsTest.cs
+++ b/src/FlaUI.WebDriver.UITests/ActionsTest.cs
@@ -48,5 +48,25 @@ namespace FlaUI.WebDriver.UITests
             string activeElmentText = _driver.SwitchTo().ActiveElement().Text;
             Assert.That(activeElmentText, Is.EqualTo("Test TextBo"));
         }
+
+        [Test]
+        public void PerformActions_MoveToElement_Click()
+        {
+            var element = _driver.FindElement(ExtendedBy.AccessibilityId("TextBox"));
+
+            new Actions(_driver).MoveToElement(element).Click().Perform();
+            string activeElementText = _driver.SwitchTo().ActiveElement().Text;
+            Assert.That(activeElementText, Is.EqualTo("Test TextBox"));
+        }
+
+        [Test]
+        public void PerformActions_MoveToElement_MoveByOffset_Click()
+        {
+            var element = _driver.FindElement(ExtendedBy.AccessibilityId("TextBox"));
+
+            new Actions(_driver).MoveToElement(element).MoveByOffset(5, 0).Click().Perform();
+            string activeElementText = _driver.SwitchTo().ActiveElement().Text;
+            Assert.That(activeElementText, Is.EqualTo("Test TextBox"));
+        }
     }
 }

--- a/src/FlaUI.WebDriver/Action.cs
+++ b/src/FlaUI.WebDriver/Action.cs
@@ -54,7 +54,7 @@ namespace FlaUI.WebDriver
         public string SubType { get; set; }
         public int? Button { get; set; }
         public int? Duration { get; set; }
-        public string? Origin { get; set; }
+        public object? Origin { get; set; }
         public int? X { get; set; }
         public int? Y { get; set; }
         public int? DeltaX { get; set; }

--- a/src/FlaUI.WebDriver/Models/ActionItem.cs
+++ b/src/FlaUI.WebDriver/Models/ActionItem.cs
@@ -1,11 +1,14 @@
-﻿namespace FlaUI.WebDriver.Models
+﻿using System.Text.Json.Serialization;
+
+namespace FlaUI.WebDriver.Models
 {
     public class ActionItem
     {
         public string Type { get; set; } = null!;
         public int? Button { get; set; }
         public int? Duration { get; set; }
-        public string? Origin { get; set; }
+        [JsonConverter(typeof(StringOrDictionaryConverter))]
+        public object? Origin { get; set; }
         public int? X { get; set; }
         public int? Y { get; set; }
         public int? DeltaX { get; set; }

--- a/src/FlaUI.WebDriver/Models/StringOrDictionaryConverter.cs
+++ b/src/FlaUI.WebDriver/Models/StringOrDictionaryConverter.cs
@@ -1,0 +1,29 @@
+﻿using System.Text.Json.Serialization;
+using System.Text.Json;
+
+namespace FlaUI.WebDriver.Models;
+
+internal class StringOrDictionaryConverter : JsonConverter<object>
+{
+    public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            return reader.GetString();
+        }
+        else if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            var dictionary = JsonSerializer.Deserialize<Dictionary<string, string>>(ref reader, options);
+            return dictionary;
+        }
+        else
+        {
+            throw new JsonException("Unexpected JSON token type.");
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
This allows `Actions.MoveToElement()` and `Actions.MoveByOffset` to work.

Added a pair of failing tests, and then a commit which fixes them.

https://www.w3.org/TR/webdriver2/#dfn-get-coordinates-relative-to-an-origin

Referenced https://github.com/appium/appium-uiautomator2-server/blob/master/app/src/main/java/io/appium/uiautomator2/utils/w3c/ActionsTokenizer.java#L307 for implementation