### PR TITLE
Make Get Element Text match WinAppDriver more closely.

### DIFF
--- a/src/FlaUI.WebDriver.UITests/ElementTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ElementTests.cs
@@ -9,40 +9,28 @@ namespace FlaUI.WebDriver.UITests
     [TestFixture]
     public class ElementTests
     {
-        [Test]
-        public void GetText_Label_ReturnsRenderedText()
+        [TestCase("TextBox", "Test TextBox")]
+        [TestCase("PasswordBox", "●●●●●●●●●●")]
+        [TestCase("EditableCombo", "Item 1")]
+        [TestCase("NonEditableCombo", "Item 1")]
+        [TestCase("ListBox", "ListBox Item #1")]
+        [TestCase("SimpleCheckBox", "Test Checkbox")]
+        [TestCase("ThreeStateCheckBox", "3-Way Test Checkbox")]
+        [TestCase("RadioButton1", "RadioButton1")]
+        [TestCase("RadioButton2", "RadioButton2")]
+        [TestCase("Slider", "5")]
+        [TestCase("InvokableButton", "Invoke me!")]
+        [TestCase("PopupToggleButton1", "Popup Toggle 1")]
+        [TestCase("Label", "Menu Item Checked")]
+        public void GetText_Returns_Correct_Text(string elementAccessibilityId, string expectedValue)
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
             using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
-            var element = driver.FindElement(ExtendedBy.AccessibilityId("Label"));
+            var element = driver.FindElement(ExtendedBy.AccessibilityId(elementAccessibilityId));
 
             var text = element.Text;
 
-            Assert.That(text, Is.EqualTo("Menu Item Checked"));
-        }
-
-        [Test]
-        public void GetText_TextBox_ReturnsTextBoxText()
-        {
-            var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
-            var element = driver.FindElement(ExtendedBy.AccessibilityId("TextBox"));
-
-            var text = element.Text;
-            
-            Assert.That(text, Is.EqualTo("Test TextBox"));
-        }
-
-        [Test]
-        public void GetText_Button_ReturnsButtonText()
-        {
-            var driverOptions = FlaUIDriverOptions.TestApp();
-            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
-            var element = driver.FindElement(ExtendedBy.AccessibilityId("InvokableButton"));
-
-            var text = element.Text;
-
-            Assert.That(text, Is.EqualTo("Invoke me!"));
+            Assert.That(text, Is.EqualTo(expectedValue));
         }
 
         [Test]

--- a/src/FlaUI.WebDriver.UITests/ElementTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ElementTests.cs
@@ -72,7 +72,6 @@ namespace FlaUI.WebDriver.UITests
 
             var text = element.Text;
 
-            // Seems that the order in which the selected items are returned is not guaranteed.
             Assert.That(text, Is.Empty);
         }
 

--- a/src/FlaUI.WebDriver.UITests/ElementTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ElementTests.cs
@@ -1,6 +1,7 @@
 ﻿using FlaUI.WebDriver.UITests.TestUtil;
 using NUnit.Framework;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Interactions;
 using OpenQA.Selenium.Remote;
 using System;
 
@@ -27,10 +28,31 @@ namespace FlaUI.WebDriver.UITests
             var driverOptions = FlaUIDriverOptions.TestApp();
             using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId(elementAccessibilityId));
-
             var text = element.Text;
 
             Assert.That(text, Is.EqualTo(expectedValue));
+        }
+
+        [Test]
+        public void GetText_Returns_Text_For_Multiple_Selection()
+        {
+            var driverOptions = FlaUIDriverOptions.TestApp();
+            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            var element = driver.FindElement(ExtendedBy.AccessibilityId("ListBox"));
+
+            new Actions(driver)
+                .MoveToElement(element)
+                .Click()
+                .KeyDown(Keys.Control)
+                .KeyDown("a")
+                .KeyUp("a")
+                .KeyUp(Keys.Control)
+                .Perform();
+
+            var text = element.Text;
+
+            // Seems that the order in which the selected items are returned is not guaranteed.
+            Assert.That(text, Is.EqualTo("ListBox Item #1, ListBox Item #2").Or.EqualTo("ListBox Item #2, ListBox Item #1"));
         }
 
         [Test]

--- a/src/FlaUI.WebDriver.UITests/ElementTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ElementTests.cs
@@ -56,6 +56,27 @@ namespace FlaUI.WebDriver.UITests
         }
 
         [Test]
+        public void GetText_Returns_Empty_String_For_No_Selection()
+        {
+            var driverOptions = FlaUIDriverOptions.TestApp();
+            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            var element = driver.FindElement(ExtendedBy.AccessibilityId("ListBox"));
+            var item = driver.FindElement(ExtendedBy.Name("ListBox Item #1"));
+
+            new Actions(driver)
+                .MoveToElement(item)
+                .KeyDown(Keys.Control)
+                .Click()
+                .KeyUp(Keys.Control)
+                .Perform();
+
+            var text = element.Text;
+
+            // Seems that the order in which the selected items are returned is not guaranteed.
+            Assert.That(text, Is.Empty);
+        }
+
+        [Test]
         public void Selected_NotCheckedCheckbox_ReturnsFalse()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();

--- a/src/FlaUI.WebDriver/Controllers/ElementController.cs
+++ b/src/FlaUI.WebDriver/Controllers/ElementController.cs
@@ -1,6 +1,7 @@
 ﻿using FlaUI.Core.AutomationElements;
 using FlaUI.WebDriver.Models;
 using Microsoft.AspNetCore.Mvc;
+using System.Diagnostics;
 using System.Text;
 
 namespace FlaUI.WebDriver.Controllers
@@ -106,8 +107,8 @@ namespace FlaUI.WebDriver.Controllers
             }
             else if (element.Patterns.Selection.IsSupported)
             {
-                var selected = element.Patterns.Selection.Pattern.Selection.Value.FirstOrDefault();
-                return selected != null ? GetElementText(selected) : string.Empty;
+                var selected = element.Patterns.Selection.Pattern.Selection.Value;
+                return string.Join(", ", selected.Select(GetElementText));
             }
             else
             {

--- a/src/FlaUI.WebDriver/Controllers/ElementController.cs
+++ b/src/FlaUI.WebDriver/Controllers/ElementController.cs
@@ -85,26 +85,34 @@ namespace FlaUI.WebDriver.Controllers
         {
             var session = GetActiveSession(sessionId);
             var element = GetElement(session, elementId);
+            var text = GetElementText(element);
 
-            string text;
+            return await Task.FromResult(WebDriverResult.Success(text));
+        }
+
+        private static string GetElementText(AutomationElement element)
+        {
             if (element.Patterns.Text.IsSupported)
             {
-                text = element.Patterns.Text.Pattern.DocumentRange.GetText(int.MaxValue);
+                return element.Patterns.Text.Pattern.DocumentRange.GetText(int.MaxValue);
             }
             else if (element.Patterns.Value.IsSupported)
             {
-                text = element.Patterns.Value.Pattern.Value.ToString();
+                return element.Patterns.Value.Pattern.Value.ToString();
             }
             else if (element.Patterns.RangeValue.IsSupported)
             {
-                text = element.Patterns.RangeValue.Pattern.Value.ToString();
+                return element.Patterns.RangeValue.Pattern.Value.ToString();
+            }
+            else if (element.Patterns.Selection.IsSupported)
+            {
+                var selected = element.Patterns.Selection.Pattern.Selection.Value.FirstOrDefault();
+                return selected != null ? GetElementText(selected) : string.Empty;
             }
             else
             {
-                text = GetRenderedText(element);
+                return GetRenderedText(element);
             }
-
-            return await Task.FromResult(WebDriverResult.Success(text));
         }
 
         private static string GetRenderedText(AutomationElement element)

--- a/src/FlaUI.WebDriver/Controllers/ElementController.cs
+++ b/src/FlaUI.WebDriver/Controllers/ElementController.cs
@@ -91,6 +91,14 @@ namespace FlaUI.WebDriver.Controllers
             {
                 text = element.Patterns.Text.Pattern.DocumentRange.GetText(int.MaxValue);
             }
+            else if (element.Patterns.Value.IsSupported)
+            {
+                text = element.Patterns.Value.Pattern.Value.ToString();
+            }
+            else if (element.Patterns.RangeValue.IsSupported)
+            {
+                text = element.Patterns.RangeValue.Pattern.Value.ToString();
+            }
             else
             {
                 text = GetRenderedText(element);

--- a/src/FlaUI.WebDriver/Controllers/ElementController.cs
+++ b/src/FlaUI.WebDriver/Controllers/ElementController.cs
@@ -93,6 +93,13 @@ namespace FlaUI.WebDriver.Controllers
 
         private static string GetElementText(AutomationElement element)
         {
+            // https://www.w3.org/TR/webdriver2/#get-element-text says about this:
+            // 
+            // > Let rendered text be the result of performing implementation-specific steps whose result is exactly
+            // > the same as the result of a Function.[[Call]](null, element) with bot.dom.getVisibleText as the this value.
+            //
+            // Because it's implementation-defined, this method tries to follow WinAppDriver's implementation as closely as
+            // possible.
             if (element.Patterns.Text.IsSupported)
             {
                 return element.Patterns.Text.Pattern.DocumentRange.GetText(int.MaxValue);

--- a/src/TestApplications/WpfApplication/MainWindow.xaml
+++ b/src/TestApplications/WpfApplication/MainWindow.xaml
@@ -40,19 +40,19 @@
                     <Label Content="Test Label" Foreground="Blue" />
                     <TextBox AutomationProperties.AutomationId="TextBox" Text="Test TextBox" Foreground="Green" x:Name="textBox"/>
                     <PasswordBox AutomationProperties.AutomationId="PasswordBox" Password="MyPassword" x:Name="passwordBox" />
-                    <ComboBox Width="120" IsEditable="True" AutomationProperties.AutomationId="EditableCombo" x:Name="editableCombo">
+                    <ComboBox Width="120" IsEditable="True" SelectedIndex="0" AutomationProperties.AutomationId="EditableCombo" x:Name="editableCombo">
                         <TextBlock Text="Item 1" AutomationProperties.AutomationId="EditableComboItem1" />
                         <TextBlock Text="Item 2" AutomationProperties.AutomationId="EditableComboItem2" />
                         <TextBlock Text="Item 3" AutomationProperties.AutomationId="EditableComboItem3" />
                     </ComboBox>
-                    <ComboBox Width="120" AutomationProperties.AutomationId="NonEditableCombo" IsEditable="False"
+                    <ComboBox Width="120" SelectedIndex="0" AutomationProperties.AutomationId="NonEditableCombo" IsEditable="False"
                             SelectionChanged="Selector_OnSelectionChanged" x:Name="nonEditableCombo">
                         <TextBlock Text="Item 1" AutomationProperties.AutomationId="EditableComboItem1" />
                         <TextBlock Text="Item 2" AutomationProperties.AutomationId="EditableComboItem2" />
                         <TextBlock Text="Item 3" AutomationProperties.AutomationId="EditableComboItem3" />
                         <TextBlock Text="Item 4" AutomationProperties.AutomationId="EditableComboItem4" />
                     </ComboBox>
-                    <ListBox AutomationProperties.AutomationId="ListBox" x:Name="listBox">
+                    <ListBox SelectedIndex="0" AutomationProperties.AutomationId="ListBox" x:Name="listBox">
                         <ListBoxItem>ListBox Item #1</ListBoxItem>
                         <ListBoxItem>ListBox Item #2</ListBoxItem>
                     </ListBox>

--- a/src/TestApplications/WpfApplication/MainWindow.xaml
+++ b/src/TestApplications/WpfApplication/MainWindow.xaml
@@ -52,7 +52,7 @@
                         <TextBlock Text="Item 3" AutomationProperties.AutomationId="EditableComboItem3" />
                         <TextBlock Text="Item 4" AutomationProperties.AutomationId="EditableComboItem4" />
                     </ComboBox>
-                    <ListBox SelectedIndex="0" AutomationProperties.AutomationId="ListBox" x:Name="listBox">
+                    <ListBox SelectedIndex="0" SelectionMode="Extended" AutomationProperties.AutomationId="ListBox" x:Name="listBox">
                         <ListBoxItem>ListBox Item #1</ListBoxItem>
                         <ListBoxItem>ListBox Item #2</ListBoxItem>
                     </ListBox>


### PR DESCRIPTION
https://www.w3.org/TR/webdriver2/#get-element-text says about this:

> Let rendered text be the result of performing implementation-specific steps whose result is exactly
> the same as the result of a Function.[[Call]](null, element) with bot.dom.getVisibleText as the this value.

Because it's implementation-defined, FlaUI.WebDriver's currently behavior is technically correct, however I feel the behavior from WinAppDriver is more useful. This PR tries to emulate that behavior by looking for various implemented patterns and using those to get the text value.

Tested against WinAppDriver's behavior and seems to match so far, with one exception noted in the comments.