### PR TITLE
On session close, don't close apps that weren't started by the WebDriver

### DIFF
--- a/src/FlaUI.WebDriver.UITests/SessionTests.cs
+++ b/src/FlaUI.WebDriver.UITests/SessionTests.cs
@@ -316,7 +316,7 @@ namespace FlaUI.WebDriver.UITests
         }
 
         [Test, Explicit(("Sometimes multiple processes are left open"))]
-        public void NewCommandTimeout_Expired_DoesNot_CloseApp_AppTopLevelWindowTitleMatch()
+        public void NewCommandTimeout_SessionWithAppTopLevelWindowTitleMatch_ClosesSessionButDoesNotCloseApp()
         {
             using var testAppProcess = new TestAppProcess();
             var driverOptions = FlaUIDriverOptions.AppTopLevelWindowTitleMatch("FlaUI WPF Test App");
@@ -330,7 +330,7 @@ namespace FlaUI.WebDriver.UITests
         }
 
         [Test]
-        public void NewCommandTimeout_Expired_DoesNot_CloseApp_AppTopLevelWindow()
+        public void NewCommandTimeout_SessionWithAppTopLevelWindow_ClosesSessionButDoesNotCloseApp()
         {
             using var testAppProcess = new TestAppProcess();
             var windowHandle = string.Format("0x{0:x}", testAppProcess.Process.MainWindowHandle);

--- a/src/FlaUI.WebDriver.UITests/SessionTests.cs
+++ b/src/FlaUI.WebDriver.UITests/SessionTests.cs
@@ -315,6 +315,35 @@ namespace FlaUI.WebDriver.UITests
             Assert.That(() => driver.Title, Throws.Nothing);
         }
 
+        [Test, Explicit(("Sometimes multiple processes are left open"))]
+        public void NewCommandTimeout_Expired_DoesNot_CloseApp_AppTopLevelWindowTitleMatch()
+        {
+            using var testAppProcess = new TestAppProcess();
+            var driverOptions = FlaUIDriverOptions.AppTopLevelWindowTitleMatch("FlaUI WPF Test App");
+            driverOptions.AddAdditionalOption("appium:newCommandTimeout", 1);
+            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+
+            System.Threading.Thread.Sleep(TimeSpan.FromSeconds(1) + WebDriverFixture.SessionCleanupInterval * 2);
+
+            Assert.That(testAppProcess.Process.HasExited, Is.False);
+            Assert.That(() => driver.Title, Throws.TypeOf<WebDriverException>().With.Message.Matches("No active session with ID '.*'"));
+        }
+
+        [Test]
+        public void NewCommandTimeout_Expired_DoesNot_CloseApp_AppTopLevelWindow()
+        {
+            using var testAppProcess = new TestAppProcess();
+            var windowHandle = string.Format("0x{0:x}", testAppProcess.Process.MainWindowHandle);
+            var driverOptions = FlaUIDriverOptions.AppTopLevelWindow(windowHandle);
+            driverOptions.AddAdditionalOption("appium:newCommandTimeout", 1);
+            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+
+            System.Threading.Thread.Sleep(TimeSpan.FromSeconds(1) + WebDriverFixture.SessionCleanupInterval * 2);
+
+            Assert.That(testAppProcess.Process.HasExited, Is.False);
+            Assert.That(() => driver.Title, Throws.TypeOf<WebDriverException>().With.Message.Matches("No active session with ID '.*'"));
+        }
+
         [TestCase("123")]
         [TestCase(false)]
         [TestCase("not a number")]

--- a/src/FlaUI.WebDriver.UITests/SessionTests.cs
+++ b/src/FlaUI.WebDriver.UITests/SessionTests.cs
@@ -129,6 +129,10 @@ namespace FlaUI.WebDriver.UITests
             var title = driver.Title;
 
             Assert.That(title, Is.EqualTo("FlaUI WPF Test App"));
+
+            driver.Quit();
+
+            Assert.That(testAppProcess.Process.HasExited, Is.False);
         }
 
         [Test]
@@ -166,6 +170,10 @@ namespace FlaUI.WebDriver.UITests
             var title = driver.Title;
 
             Assert.That(title, Is.EqualTo("FlaUI WPF Test App"));
+
+            driver.Quit();
+
+            Assert.That(testAppProcess.Process.HasExited, Is.False);
         }
 
         [Test, Ignore("Sometimes multiple processes are left open")]

--- a/src/FlaUI.WebDriver/Controllers/SessionController.cs
+++ b/src/FlaUI.WebDriver/Controllers/SessionController.cs
@@ -30,6 +30,7 @@ namespace FlaUI.WebDriver.Controllers
                 .Select(capabillities => matchedCapabilities!);
 
             Core.Application? app;
+            var isAppOwnedBySession = false;
             var capabilities = matchingCapabilities.FirstOrDefault();
             if (capabilities == null)
             {
@@ -69,6 +70,8 @@ namespace FlaUI.WebDriver.Controllers
                         throw WebDriverResponseException.InvalidArgument($"Starting app '{appPath}' with arguments '{appArguments}' threw an exception: {e.Message}");
                     }
                 }
+
+                isAppOwnedBySession = true;
             }
             else if (TryGetStringCapability(capabilities, "appium:appTopLevelWindow", out var appTopLevelWindowString))
             {
@@ -84,7 +87,7 @@ namespace FlaUI.WebDriver.Controllers
             {
                 throw WebDriverResponseException.InvalidArgument("One of appium:app, appium:appTopLevelWindow or appium:appTopLevelWindowTitleMatch must be passed as a capability");
             }
-            var session = new Session(app);
+            var session = new Session(app, isAppOwnedBySession);
             if(TryGetNumberCapability(capabilities, "appium:newCommandTimeout", out var newCommandTimeout))
             {
                 session.NewCommandTimeout = TimeSpan.FromSeconds(newCommandTimeout);

--- a/src/FlaUI.WebDriver/Session.cs
+++ b/src/FlaUI.WebDriver/Session.cs
@@ -6,13 +6,14 @@ namespace FlaUI.WebDriver
 {
     public class Session : IDisposable
     {
-        public Session(Application? app)
+        public Session(Application? app, bool isAppOwnedBySession)
         {
             App = app;
             SessionId = Guid.NewGuid().ToString();
             Automation = new UIA3Automation();
             InputState = new InputState();
             TimeoutsConfiguration = new TimeoutsConfiguration();
+            IsAppOwnedBySession = isAppOwnedBySession;
 
             if (app != null)
             {
@@ -30,6 +31,7 @@ namespace FlaUI.WebDriver
         public TimeSpan ImplicitWaitTimeout => TimeSpan.FromMilliseconds(TimeoutsConfiguration.ImplicitWaitTimeoutMs);
         public TimeSpan PageLoadTimeout => TimeSpan.FromMilliseconds(TimeoutsConfiguration.PageLoadTimeoutMs);
         public TimeSpan? ScriptTimeout => TimeoutsConfiguration.ScriptTimeoutMs.HasValue ? TimeSpan.FromMilliseconds(TimeoutsConfiguration.ScriptTimeoutMs.Value) : null;
+        public bool IsAppOwnedBySession { get; }
 
         public TimeoutsConfiguration TimeoutsConfiguration { get; set; }
 
@@ -124,7 +126,7 @@ namespace FlaUI.WebDriver
 
         public void Dispose()
         {
-            if (App != null && !App.HasExited)
+            if (IsAppOwnedBySession && App != null && !App.HasExited)
             {
                 App.Close();
             }


### PR DESCRIPTION
When a session finishes or times out, don't close the app if the session was attached to an existing app using `appTopLevelWindow` or `appTopLevelWindowTitleMatch`.

This feels like intuitive behavior to me: the app was running before the session started so one can assume that the user is in control of the app lifetime.

Added a commit with failing tests, and a commit with a simple fix.