### PR TITLE
Reinstate usage of GetAllTopLevelWindows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,15 +131,12 @@ The driver supports switching windows. The behavior of windows is as following (
 
 - By default, the window is the window that the application was started with.
 - The window does not change if the app/user opens another window, also not if that window happens to be on the foreground.
-- ~~All open window handles from the same app process (same process ID in Windows) can be retrieved.~~ Currently only the main window and modal windows are returned when getting window handles. See issue below.
+- All open window handles from the same app process (same process ID in Windows) can be retrieved.
 - Other processes spawned by the app that open windows are not visible as window handles.
   Those can be automated by starting a new driver session with e.g. the `appium:appTopLevelWindow` capability.
 - Closing a window does not automatically switch the window handle.
   That means that after closing a window, most commands will return an error "no such window" until the window is switched.
 - Switching to a window will set that window in the foreground.
-
-> [!IMPORTANT]
-> Currently only the main window and modal windows are returned when getting window handles. See <https://github.com/FlaUI/FlaUI/issues/596>
 
 ## Running scripts
 

--- a/src/FlaUI.WebDriver.UITests/WindowTests.cs
+++ b/src/FlaUI.WebDriver.UITests/WindowTests.cs
@@ -63,20 +63,20 @@ namespace FlaUI.WebDriver.UITests
             Assert.That(windowHandleAfterOpenCloseOtherWindow, Is.EqualTo(initialWindowHandle));
         }
 
-        [Test, Ignore("https://github.com/FlaUI/FlaUI/issues/596")]
+        [Test]
         public void GetWindowHandle_WindowClosed_ReturnsNoSuchWindow()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
             using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
-            OpenAndSwitchToNewWindow(driver);
+            var newWindowHandle = OpenAndSwitchToNewWindow(driver);
             driver.Close();
 
             var getWindowHandle = () => driver.CurrentWindowHandle;
 
-            Assert.That(getWindowHandle, Throws.TypeOf<NoSuchWindowException>().With.Message.EqualTo("Test"));
+            Assert.That(getWindowHandle, Throws.TypeOf<NoSuchWindowException>().With.Message.EqualTo($"No window found with handle '{newWindowHandle}'"));
         }
 
-        [Test, Ignore("https://github.com/FlaUI/FlaUI/issues/596")]
+        [Test]
         public void GetWindowHandles_Default_ReturnsUniqueHandlePerWindow()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
@@ -146,12 +146,13 @@ namespace FlaUI.WebDriver.UITests
             Assert.That(element.Text, Is.EqualTo("Invoked!"));
         }
 
-        private static void OpenAndSwitchToNewWindow(RemoteWebDriver driver)
+        private static string OpenAndSwitchToNewWindow(RemoteWebDriver driver)
         {
             var initialWindowHandle = driver.CurrentWindowHandle;
             OpenAnotherWindow(driver);
             var newWindowHandle = driver.WindowHandles.Except(new[] { initialWindowHandle }).Single();
             driver.SwitchTo().Window(newWindowHandle);
+            return newWindowHandle;
         }
 
         private static void OpenAnotherWindow(RemoteWebDriver driver)

--- a/src/FlaUI.WebDriver/Controllers/WindowController.cs
+++ b/src/FlaUI.WebDriver/Controllers/WindowController.cs
@@ -141,9 +141,7 @@ namespace FlaUI.WebDriver.Controllers
                 return Enumerable.Empty<string>();
             }
 
-            // GetAllTopLevelWindows sometimes times out, so we return only the main window and modal windows
-            // https://github.com/FlaUI/FlaUI/issues/596
-            var knownWindows = mainWindow.ModalWindows.Prepend(mainWindow)
+            var knownWindows = session.App.GetAllTopLevelWindows(session.Automation)
                 .Select(session.GetOrAddKnownWindow);
             return knownWindows.Select(knownWindows => knownWindows.WindowHandle);
         }

--- a/src/FlaUI.WebDriver/Controllers/WindowController.cs
+++ b/src/FlaUI.WebDriver/Controllers/WindowController.cs
@@ -135,11 +135,6 @@ namespace FlaUI.WebDriver.Controllers
             {
                 return Enumerable.Empty<string>();
             }
-            var mainWindow = session.App.GetMainWindow(session.Automation, TimeSpan.Zero);
-            if (mainWindow == null)
-            {
-                return Enumerable.Empty<string>();
-            }
 
             var knownWindows = session.App.GetAllTopLevelWindows(session.Automation)
                 .Select(session.GetOrAddKnownWindow);


### PR DESCRIPTION
Not sure what you'll think about this one but this PR reinstates the use of `GetAllTopLevelWindows`. This was removed due to https://github.com/FlaUI/FlaUI/issues/596, which I would like to investigate, however I've so far been unable to repro the issue. Maybe if the failing code path is enabled then I'll hit it and will be able to investigate.

Also, I need to be able to retrieve all open window handles, so only returning the main window and modal windows is a problem for me...