### PR TITLE
Make WebDriver DPI scaling-aware.

### DIFF
--- a/src/FlaUI.WebDriver.UITests/ElementTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ElementTests.cs
@@ -168,7 +168,7 @@ namespace FlaUI.WebDriver.UITests
             using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId("EditableCombo"));
 
-            var scaling = double.Parse(driver.FindElement(ExtendedBy.AccessibilityId("DpiScaling")).Text.ToString());
+            var scaling = TestApplication.GetScaling(driver);
             var location = element.Location;
             var size = element.Size;
 

--- a/src/FlaUI.WebDriver.UITests/ElementTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ElementTests.cs
@@ -168,14 +168,15 @@ namespace FlaUI.WebDriver.UITests
             using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
             var element = driver.FindElement(ExtendedBy.AccessibilityId("EditableCombo"));
 
+            var scaling = double.Parse(driver.FindElement(ExtendedBy.AccessibilityId("DpiScaling")).Text.ToString());
             var location = element.Location;
             var size = element.Size;
 
             var windowLocation = driver.Manage().Window.Position;
-            Assert.That(location.X, Is.InRange(windowLocation.X + 253, windowLocation.X + 257));
-            Assert.That(location.Y, Is.InRange(windowLocation.Y + 132, windowLocation.Y + 136));
-            Assert.That(size.Width, Is.EqualTo(120));
-            Assert.That(size.Height, Is.EqualTo(22));
+            Assert.That(location.X, Is.InRange(windowLocation.X + (253 * scaling), windowLocation.X + (257 * scaling)));
+            Assert.That(location.Y, Is.InRange(windowLocation.Y + (132 * scaling), windowLocation.Y + (136 * scaling)));
+            Assert.That(size.Width, Is.EqualTo(120 * scaling));
+            Assert.That(size.Height, Is.EqualTo(22 * scaling));
         }
 
         [TestCase("TextBox")]

--- a/src/FlaUI.WebDriver.UITests/TestUtil/TestApplication.cs
+++ b/src/FlaUI.WebDriver.UITests/TestUtil/TestApplication.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using OpenQA.Selenium.Remote;
 
 namespace FlaUI.WebDriver.UITests.TestUtil
 {
@@ -8,6 +9,11 @@ namespace FlaUI.WebDriver.UITests.TestUtil
 
         private static readonly string s_currentDirectory = Directory.GetCurrentDirectory();
         private static readonly string s_solutionDirectory = FindSolutionDirectory(s_currentDirectory);
+
+        public static double GetScaling(RemoteWebDriver driver)
+        {
+            return double.Parse(driver.FindElement(ExtendedBy.AccessibilityId("DpiScaling")).Text.ToString());
+        }
 
         private static string FindSolutionDirectory(string currentDirectory)
         {

--- a/src/FlaUI.WebDriver.UITests/WindowTests.cs
+++ b/src/FlaUI.WebDriver.UITests/WindowTests.cs
@@ -15,13 +15,14 @@ namespace FlaUI.WebDriver.UITests
             var driverOptions = FlaUIDriverOptions.TestApp();
             using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
+            var scaling = double.Parse(driver.FindElement(ExtendedBy.AccessibilityId("DpiScaling")).Text.ToString());
             var position = driver.Manage().Window.Position;
             var size = driver.Manage().Window.Size;
 
             Assert.That(position.X, Is.GreaterThanOrEqualTo(0));
             Assert.That(position.Y, Is.GreaterThanOrEqualTo(0));
-            Assert.That(size.Width, Is.InRange(629, 630));
-            Assert.That(size.Height, Is.InRange(515, 516));
+            Assert.That(size.Width, Is.InRange(629 * scaling, 630 * scaling));
+            Assert.That(size.Height, Is.InRange(515 * scaling, 516 * scaling));
         }
 
         [Test]

--- a/src/FlaUI.WebDriver.UITests/WindowTests.cs
+++ b/src/FlaUI.WebDriver.UITests/WindowTests.cs
@@ -15,7 +15,7 @@ namespace FlaUI.WebDriver.UITests
             var driverOptions = FlaUIDriverOptions.TestApp();
             using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
 
-            var scaling = double.Parse(driver.FindElement(ExtendedBy.AccessibilityId("DpiScaling")).Text.ToString());
+            var scaling = TestApplication.GetScaling(driver);
             var position = driver.Manage().Window.Position;
             var size = driver.Manage().Window.Size;
 

--- a/src/FlaUI.WebDriver/FlaUI.WebDriver.csproj
+++ b/src/FlaUI.WebDriver/FlaUI.WebDriver.csproj
@@ -9,6 +9,7 @@
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FlaUI.WebDriver/app.manifest
+++ b/src/FlaUI.WebDriver/app.manifest
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>

--- a/src/TestApplications/WpfApplication/MainWindow.xaml
+++ b/src/TestApplications/WpfApplication/MainWindow.xaml
@@ -32,7 +32,9 @@
             </MenuItem>
         </Menu>
         <StatusBar DockPanel.Dock="Bottom">
-            <StatusBarItem />
+            <StatusBarItem>
+                <TextBlock x:Name="DpiScaling"/>
+            </StatusBarItem>
         </StatusBar>
         <TabControl>
             <TabItem Header="Simple Controls">

--- a/src/TestApplications/WpfApplication/MainWindow.xaml.cs
+++ b/src/TestApplications/WpfApplication/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 
 namespace WpfApplication
 {
@@ -25,6 +26,12 @@ namespace WpfApplication
                     MessageBox.Show("Do you really want to do it?");
                 }
             }
+        }
+
+        protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
+        {
+            DpiScaling.Text = VisualTreeHelper.GetDpi(this).DpiScaleX.ToString();
+            base.OnRenderSizeChanged(sizeInfo);
         }
 
         private void OnShowLabel(object sender, RoutedEventArgs e)

--- a/src/TestApplications/WpfApplication/WpfApplication.csproj
+++ b/src/TestApplications/WpfApplication/WpfApplication.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -6,7 +6,8 @@
     <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-	<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
 </Project>

--- a/src/TestApplications/WpfApplication/app.manifest
+++ b/src/TestApplications/WpfApplication/app.manifest
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>


### PR DESCRIPTION
This PR makes the WebDriver process DPI scaling aware. If this is not done then capturing screenshots [will not work on monitors with scaling other than 100%](https://github.com/FlaUI/FlaUI/issues/359) and sometimes [element positioning is miscalculated](https://github.com/FlaUI/FlaUI/issues/306).

It also makes the test application DPI-aware as it needs to communicate the current scaling factor to the unit tests. The test application exposes its current DPI scaling in the status bar, and this is read in tests that require checking bounds/positions.

Note that WinAppDriver is also DPI aware so this should also help match the behavior there.