### PR TITLE
Evict unavailable elements and improve element compare performance

### DIFF
--- a/src/FlaUI.WebDriver.UITests/FindElementsTests.cs
+++ b/src/FlaUI.WebDriver.UITests/FindElementsTests.cs
@@ -227,6 +227,23 @@ namespace FlaUI.WebDriver.UITests
             Assert.That(elementsInNewWindow, Has.Count.EqualTo(1));
         }
 
+        [Test]
+        public void FindElements_AfterPreviousKnownElementUnavailable_DoesNotThrow()
+        {
+            var driverOptions = FlaUIDriverOptions.TestApp();
+            using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions);
+            var initialWindowHandle = driver.CurrentWindowHandle;
+            OpenAndSwitchToAnotherWindow(driver);
+            var elementInNewWindow = driver.FindElement(ExtendedBy.AccessibilityId("Window1TextBox"));
+            // close to make the elementInNewWindow unavailable
+            driver.Close();
+            driver.SwitchTo().Window(initialWindowHandle);
+
+            var foundElements = driver.FindElements(ExtendedBy.AccessibilityId("TextBox"));
+
+            Assert.That(foundElements, Has.Count.EqualTo(1));
+        }
+
         private static void OpenAndSwitchToAnotherWindow(RemoteWebDriver driver)
         {
             var initialWindowHandles = new[] { driver.CurrentWindowHandle };

--- a/src/FlaUI.WebDriver/ISessionRepository.cs
+++ b/src/FlaUI.WebDriver/ISessionRepository.cs
@@ -4,6 +4,7 @@
     {
         void Add(Session session);
         void Delete(Session session);
+        List<Session> FindAll();
         Session? FindById(string sessionId);
         List<Session> FindTimedOut();
     }

--- a/src/FlaUI.WebDriver/KnownElement.cs
+++ b/src/FlaUI.WebDriver/KnownElement.cs
@@ -4,13 +4,22 @@ namespace FlaUI.WebDriver
 {
     public class KnownElement
     {
-        public KnownElement(AutomationElement element)
+        public KnownElement(AutomationElement element, string? elementRuntimeId)
         {
             Element = element;
+            ElementRuntimeId = elementRuntimeId;
             ElementReference = Guid.NewGuid().ToString();
         }
 
-        public string ElementReference { get; set; }
+        public string ElementReference { get; }
+
+        /// <summary>
+        /// A temporarily unique ID, so cannot be used for identity over time, but can be used for improving performance of equality tests.
+        /// "The identifier is only guaranteed to be unique to the UI of the desktop on which it was generated. Identifiers can be reused over time."
+        /// </summary>
+        /// <seealso href="https://learn.microsoft.com/en-us/windows/win32/api/uiautomationclient/nf-uiautomationclient-iuiautomationelement-getruntimeid"/>
+        public string? ElementRuntimeId { get; }
+
         public AutomationElement Element { get; }
     }
 }

--- a/src/FlaUI.WebDriver/KnownWindow.cs
+++ b/src/FlaUI.WebDriver/KnownWindow.cs
@@ -4,12 +4,21 @@ namespace FlaUI.WebDriver
 {
     public class KnownWindow
     {
-        public KnownWindow(Window window)
+        public KnownWindow(Window window, string? windowRuntimeId)
         {
             Window = window;
+            WindowRuntimeId = windowRuntimeId;
             WindowHandle = Guid.NewGuid().ToString();
         }
         public string WindowHandle { get; set; }
+
+        /// <summary>
+        /// A temporarily unique ID, so cannot be used for identity over time, but can be used for improving performance of equality tests.
+        /// "The identifier is only guaranteed to be unique to the UI of the desktop on which it was generated. Identifiers can be reused over time."
+        /// </summary>
+        /// <seealso href="https://learn.microsoft.com/en-us/windows/win32/api/uiautomationclient/nf-uiautomationclient-iuiautomationelement-getruntimeid"/>
+        public string? WindowRuntimeId { get; set; }
+
         public Window Window { get; set; }
     }
 }

--- a/src/FlaUI.WebDriver/Session.cs
+++ b/src/FlaUI.WebDriver/Session.cs
@@ -124,6 +124,26 @@ namespace FlaUI.WebDriver
             }
         }
 
+        public void EvictUnavailableElements()
+        {
+            // Evict unavailable elements to prevent slowing down
+            var unavailableElements = KnownElementsByElementReference.Where(item => !item.Value.Element.IsAvailable).Select(item => item.Key).ToArray();
+            foreach (var unavailableElementKey in unavailableElements)
+            {
+                KnownElementsByElementReference.Remove(unavailableElementKey);
+            }
+        }
+
+        public void EvictUnavailableWindows()
+        {
+            // Evict unavailable windows to prevent slowing down
+            var unavailableWindows = KnownWindowsByWindowHandle.Where(item => !item.Value.Window.IsAvailable).Select(item => item.Key).ToArray();
+            foreach (var unavailableWindowKey in unavailableWindows)
+            {
+                KnownWindowsByWindowHandle.Remove(unavailableWindowKey);
+            }
+        }
+
         public void Dispose()
         {
             if (IsAppOwnedBySession && App != null && !App.HasExited)

--- a/src/FlaUI.WebDriver/SessionRepository.cs
+++ b/src/FlaUI.WebDriver/SessionRepository.cs
@@ -23,5 +23,10 @@
         {
             return Sessions.Where(session => session.IsTimedOut).ToList();
         }
+
+        public List<Session> FindAll()
+        {
+            return new List<Session>(Sessions);
+        }
     }
 }


### PR DESCRIPTION
Evict unavailable elements to prevent COM exceptions and to free memory. See https://github.com/FlaUI/FlaUI.WebDriver/issues/35. The COM exceptions from a growing set of unavailable elements may be the cause of degrading performance as well.