### PR TITLE
Add input sources in GetOrCreateInputSource

### DIFF
--- a/src/FlaUI.WebDriver/Controllers/ActionsController.cs
+++ b/src/FlaUI.WebDriver/Controllers/ActionsController.cs
@@ -71,12 +71,7 @@ namespace FlaUI.WebDriver.Controllers
                 // TODO: Implement other input source types.
                 if (actionSequence.Type == "key")
                 {
-                    var source = session.InputState.GetOrCreateInputSource(actionSequence.Type, actionSequence.Id);
-
-                    // The spec says that input sources must be created for actions and they are later expected to be
-                    // found in the input source map, but doesn't specify what should add them. Guessing that it should
-                    // be done here. https://github.com/w3c/webdriver/issues/1810
-                    session.InputState.AddInputSource(actionSequence.Id, source);
+                    session.InputState.GetOrCreateInputSource(actionSequence.Type, actionSequence.Id);
                 }
 
                 for (var tickIndex = 0; tickIndex < actionSequence.Actions.Count; tickIndex++)

--- a/src/FlaUI.WebDriver/InputState.cs
+++ b/src/FlaUI.WebDriver/InputState.cs
@@ -74,7 +74,8 @@ namespace FlaUI.WebDriver
         /// </summary>
         /// <remarks>
         /// Implements "get or create an input source" from https://www.w3.org/TR/webdriver2/#input-state
-        /// Note: The spec does not specify that a created input source should be added to the input state map.
+        /// Note: The spec does not specify that a created input source should be added to the input state map
+        /// but this implementation does.
         /// </remarks>
         public InputSource GetOrCreateInputSource(string type, string id)
         {
@@ -86,7 +87,16 @@ namespace FlaUI.WebDriver
                     $"Input source with id '{id}' already exists and has a different type: {source.Type}");
             }
 
-            return CreateInputSource(type);
+            // Note: The spec does not specify that a created input source should be added to the input state map,
+            // however it needs to be added somewhere. The caller can't do it because it doesn't know if the source
+            // was created or already existed. See https://github.com/w3c/webdriver/issues/1810
+            if (source == null)
+            {
+                source = CreateInputSource(type);
+                AddInputSource(id, source);
+            }
+
+            return source;
         }
 
         /// <summary>


### PR DESCRIPTION
The spec is unclear on when input sources should be added to the input source map. Previously it was being done in `ExtractActionSequence` but the problem with doing it there is that there's no way to know if `GetOrCreateInputSource` is returning an existing input source or creating a new one, causing #43.

Move the logic to add an input source to `GetOrCreateInputSource` to fix  this.

(It would kinda make sense to do it instead in `CreateInputSource` but the spec defines callers of this method which add the input source manually :/ )

Fixes #43