### PR TITLE
Better capability matching errors

### DIFF
--- a/src/FlaUI.WebDriver.UITests/SessionTests.cs
+++ b/src/FlaUI.WebDriver.UITests/SessionTests.cs
@@ -17,30 +17,30 @@ namespace FlaUI.WebDriver.UITests
 
             var newSession = () => new RemoteWebDriver(WebDriverFixture.WebDriverUrl, emptyOptions);
 
-            Assert.That(newSession, Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("Required capabilities did not match. Capability `platformName` with value `windows` is required, capability 'appium:automationName' with value `FlaUI` is required, and one of appium:app, appium:appTopLevelWindow or appium:appTopLevelWindowTitleMatch must be passed as a capability (SessionNotCreated)"));
+            Assert.That(newSession, Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("Missing capability 'platformName' with value 'windows' (SessionNotCreated)"));
         }
 
         [Test]
         public void NewSession_AutomationNameMissing_ReturnsError()
         {
             var emptyOptions = FlaUIDriverOptions.Empty();
-            emptyOptions.AddAdditionalOption("appium:platformName", "windows");
+            emptyOptions.PlatformName = "Windows";
 
             var newSession = () => new RemoteWebDriver(WebDriverFixture.WebDriverUrl, emptyOptions);
 
-            Assert.That(newSession, Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("Required capabilities did not match. Capability `platformName` with value `windows` is required, capability 'appium:automationName' with value `FlaUI` is required, and one of appium:app, appium:appTopLevelWindow or appium:appTopLevelWindowTitleMatch must be passed as a capability (SessionNotCreated)"));
+            Assert.That(newSession, Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("Missing capability 'appium:automationName' with value 'flaui' (SessionNotCreated)"));
         }
 
         [Test]
         public void NewSession_AllAppCapabilitiesMissing_ReturnsError()
         {
             var emptyOptions = FlaUIDriverOptions.Empty();
-            emptyOptions.AddAdditionalOption("appium:platformName", "windows");
+            emptyOptions.PlatformName = "Windows";
             emptyOptions.AddAdditionalOption("appium:automationName", "windows");
 
             var newSession = () => new RemoteWebDriver(WebDriverFixture.WebDriverUrl, emptyOptions);
 
-            Assert.That(newSession, Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("Required capabilities did not match. Capability `platformName` with value `windows` is required, capability 'appium:automationName' with value `FlaUI` is required, and one of appium:app, appium:appTopLevelWindow or appium:appTopLevelWindowTitleMatch must be passed as a capability (SessionNotCreated)"));
+            Assert.That(newSession, Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("Missing capability 'appium:automationName' with value 'flaui' (SessionNotCreated)"));
         }
 
         [Test]
@@ -115,7 +115,7 @@ namespace FlaUI.WebDriver.UITests
             driverOptions.AddAdditionalOption("unknown:unknown", "value");
 
             Assert.That(() => new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions),
-                Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("Required capabilities did not match. Capability `platformName` with value `windows` is required, capability 'appium:automationName' with value `FlaUI` is required, and one of appium:app, appium:appTopLevelWindow or appium:appTopLevelWindowTitleMatch must be passed as a capability (SessionNotCreated)"));
+                Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("The following capabilities could not be matched: 'unknown:unknown' (SessionNotCreated)"));
         }
 
         [Test]
@@ -158,7 +158,7 @@ namespace FlaUI.WebDriver.UITests
             Assert.That(newSession, Throws.TypeOf<WebDriverArgumentException>().With.Message.EqualTo("Capability appium:appTopLevelWindow '0x0' should not be zero"));
         }
 
-        [Ignore("Sometimes multiple processes are left open")]
+        [Explicit("Sometimes multiple processes are left open")]
         [TestCase("FlaUI WPF Test App")]
         [TestCase("FlaUI WPF .*")]
         public void NewSession_AppTopLevelWindowTitleMatch_IsSupported(string match)
@@ -176,7 +176,7 @@ namespace FlaUI.WebDriver.UITests
             Assert.That(testAppProcess.Process.HasExited, Is.False);
         }
 
-        [Test, Ignore("Sometimes multiple processes are left open")]
+        [Test, Explicit("Sometimes multiple processes are left open")]
         public void NewSession_AppTopLevelWindowTitleMatchMultipleMatching_ReturnsError()
         {
             using var testAppProcess = new TestAppProcess();

--- a/src/FlaUI.WebDriver/MergedCapabilities.cs
+++ b/src/FlaUI.WebDriver/MergedCapabilities.cs
@@ -1,0 +1,94 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+namespace FlaUI.WebDriver
+{
+    public class MergedCapabilities
+    {
+        public Dictionary<string, JsonElement> Capabilities { get; }
+
+        public MergedCapabilities(Dictionary<string, JsonElement> firstMatchCapabilities, Dictionary<string, JsonElement> requiredCapabilities) 
+            : this(MergeCapabilities(firstMatchCapabilities, requiredCapabilities))
+        {
+            
+        }
+
+        public MergedCapabilities(Dictionary<string, JsonElement> capabilities)
+        {
+            Capabilities = capabilities;
+        }
+
+        private static Dictionary<string, JsonElement> MergeCapabilities(Dictionary<string, JsonElement> firstMatchCapabilities, Dictionary<string, JsonElement> requiredCapabilities)
+        {
+            var duplicateKeys = firstMatchCapabilities.Keys.Intersect(requiredCapabilities.Keys);
+            if (duplicateKeys.Any())
+            {
+                throw WebDriverResponseException.InvalidArgument($"Capabilities cannot be merged because there are duplicate capabilities: {string.Join(", ", duplicateKeys)}");
+            }
+
+            return firstMatchCapabilities.Concat(requiredCapabilities)
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        }
+
+        public bool TryGetStringCapability(string key, [MaybeNullWhen(false)] out string value)
+        {
+            if (Capabilities.TryGetValue(key, out var valueJson))
+            {
+                if (valueJson.ValueKind != JsonValueKind.String)
+                {
+                    throw WebDriverResponseException.InvalidArgument($"Capability {key} must be a string");
+                }
+
+                value = valueJson.GetString();
+                return value != null;
+            }
+
+            value = null;
+            return false;
+        }
+
+        public bool TryGetNumberCapability(string key, out double value)
+        {
+            if (Capabilities.TryGetValue(key, out var valueJson))
+            {
+                if (valueJson.ValueKind != JsonValueKind.Number)
+                {
+                    throw WebDriverResponseException.InvalidArgument($"Capability {key} must be a number");
+                }
+
+                value = valueJson.GetDouble();
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        public void Copy(string key, MergedCapabilities fromCapabilities)
+        {
+            Capabilities.Add(key, fromCapabilities.Capabilities[key]);
+        }
+
+        public bool Contains(string key)
+        {
+            return Capabilities.ContainsKey(key);
+        }
+
+        public bool TryGetCapability<T>(string key, [MaybeNullWhen(false)] out T? value)
+        {
+            if (!Capabilities.TryGetValue(key, out var valueJson))
+            {
+                value = default;
+                return false;
+            }
+
+            var deserializedValue = JsonSerializer.Deserialize<T>(valueJson);
+            if (deserializedValue == null)
+            {
+                throw WebDriverResponseException.InvalidArgument($"Could not deserialize {key} capability");
+            }
+            value = deserializedValue;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Use very specific error messages to indicate capability mismatches. Closes #26. 