### PR TITLE
Update to .NET 8 🎉

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/src/FlaUI.WebDriver.UITests/FlaUI.WebDriver.UITests.csproj
+++ b/src/FlaUI.WebDriver.UITests/FlaUI.WebDriver.UITests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
 
     <IsPackable>false</IsPackable>
 	  <LangVersion>preview</LangVersion>

--- a/src/FlaUI.WebDriver/FlaUI.WebDriver.csproj
+++ b/src/FlaUI.WebDriver/FlaUI.WebDriver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup Label="Build">
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>

--- a/src/TestApplications/WpfApplication/WpfApplication.csproj
+++ b/src/TestApplications/WpfApplication/WpfApplication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>


### PR DESCRIPTION
Update because .NET 8 is the latest LTS, released November 2023 (see https://dotnet.microsoft.com/en-us/platform/support/policy).

FlaUI itself is .NET 6-based still, but can be used from .NET 8 projects: https://github.com/FlaUI/FlaUI/issues/611.