### PR TITLE
Fix dependabot directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: "/"
+    directory: "/src"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Attempt to fix dependabot, which is running daily but does not discover any projects:

```
  No dotnet-tools.json file found.
  No global.json file found.
  Discovering projects beneath [.].
  No project files found.
  Central Package Management is not enabled.
```