### PR TITLE
Ignore exception on scrolling element into view

### DIFF
--- a/src/FlaUI.WebDriver/Controllers/ElementController.cs
+++ b/src/FlaUI.WebDriver/Controllers/ElementController.cs
@@ -271,9 +271,17 @@ namespace FlaUI.WebDriver.Controllers
             return await Task.FromResult(WebDriverResult.Success(elementRect));
         }
 
-        private static void ScrollElementContainerIntoView(AutomationElement element)
+        private void ScrollElementContainerIntoView(AutomationElement element)
         {
-            element.Patterns.ScrollItem.PatternOrDefault?.ScrollIntoView();
+            try
+            {
+                element.Patterns.ScrollItem.PatternOrDefault?.ScrollIntoView();
+            }
+            catch (InvalidOperationException e)
+            {
+                // Ignore if scroll fails because of "Operation is not valid due to the current state of the object"
+                _logger.LogDebug(e, "Ignoring exception: Could not scroll element {Element} into view", element);
+            }
         }
 
         private static ActionResult ElementNotInteractable(string elementId)


### PR DESCRIPTION
Ignore exception on scrolling into view of an element before element click or element send keys.

Closes #75.