### PR TITLE
Ignore not matched capabilities

### DIFF
--- a/src/FlaUI.WebDriver.UITests/SessionTests.cs
+++ b/src/FlaUI.WebDriver.UITests/SessionTests.cs
@@ -106,13 +106,23 @@ namespace FlaUI.WebDriver.UITests
         }
 
         [Test]
-        public void NewSession_NotSupportedCapability_Throws()
+        public void NewSession_NotSupportedAppiumCapability_Throws()
+        {
+            var driverOptions = FlaUIDriverOptions.TestApp();
+            driverOptions.AddAdditionalOption("appium:unknown", "value");
+
+            Assert.That(() => { using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions); },
+                Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("The following capabilities could not be matched: 'appium:unknown' (SessionNotCreated)"));
+        }
+
+        [Test]
+        public void NewSession_UnknownExtensionCapability_Ignores()
         {
             var driverOptions = FlaUIDriverOptions.TestApp();
             driverOptions.AddAdditionalOption("unknown:unknown", "value");
 
-            Assert.That(() => new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions),
-                Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("The following capabilities could not be matched: 'unknown:unknown' (SessionNotCreated)"));
+            Assert.That(() => { using var driver = new RemoteWebDriver(WebDriverFixture.WebDriverUrl, driverOptions); },
+                Throws.Nothing);
         }
 
         [Test]

--- a/src/FlaUI.WebDriver/Controllers/SessionController.cs
+++ b/src/FlaUI.WebDriver/Controllers/SessionController.cs
@@ -200,10 +200,16 @@ namespace FlaUI.WebDriver.Controllers
             }
 
             var notMatchedCapabilities = capabilities.Capabilities.Keys.Except(matchedCapabilities.Capabilities.Keys);
+            var notMatchedStandardOrAppiumCapabilities = notMatchedCapabilities.Where(c => !c.Contains(":") || c.StartsWith("appium:"));
+            if (notMatchedStandardOrAppiumCapabilities.Any())
+            {
+                // Do not ignore non-extension capabilities or appium capabilities
+                mismatchIndication = $"The following capabilities could not be matched: '{string.Join("', '", notMatchedStandardOrAppiumCapabilities)}'";
+                return false;            
+            }
             if (notMatchedCapabilities.Any())
             {
-                mismatchIndication = $"The following capabilities could not be matched: '{string.Join("', '", notMatchedCapabilities)}'";
-                return false;
+                _logger.LogDebug("The following capabilities could not be matched and are ignored: '{NotMatchedCapabilities}'", string.Join("', '", notMatchedCapabilities));
             }
 
             mismatchIndication = null;


### PR DESCRIPTION
Instead of returning 'session not created' when not all capabilities were matched, ignore not matching capabilities. I am not sure whether this is to the letter of the standard, but it will not do much harm except for users that may be surprised if FlaUI.WebDriver just ignores their supplied capability which is not implemented for FlaUI.WebDriver yet.

Fixes #100.