### PR TITLE
Add scroll script and fix other Windows extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ Using the WebdriverIO JavaScript client:
 const result = driver.executeScript("powerShell", [{ command: `1+1` }]);
 ```
 
+## Windows extensions
+
+To enable easy switching from appium-windows-driver, there is a rudimentary implementation of `windows: click`, `windows: hover`, `windows: scroll` and `windows: keys`.
+
 ## Supported WebDriver Commands
 
 | Method | URI Template                                                   | Command                        | Implemented                        |

--- a/src/FlaUI.WebDriver/Controllers/ExecuteController.cs
+++ b/src/FlaUI.WebDriver/Controllers/ExecuteController.cs
@@ -35,8 +35,10 @@ namespace FlaUI.WebDriver.Controllers
                     return await ExecuteWindowsClickScript(session, executeScriptRequest);
                 case "windows: hover":
                     return await ExecuteWindowsHoverScript(session, executeScriptRequest);
+                case "windows: scroll":
+                    return await ExecuteWindowsScrollScript(session, executeScriptRequest);
                 default:
-                    throw WebDriverResponseException.UnsupportedOperation("Only 'powerShell' scripts are supported");
+                    throw WebDriverResponseException.UnsupportedOperation("Only 'powerShell', 'windows: keys', 'windows: click', 'windows: hover' scripts are supported");
             }
         }
 
@@ -100,6 +102,21 @@ namespace FlaUI.WebDriver.Controllers
                 throw WebDriverResponseException.InvalidArgument("Action cannot be null");
             }
             await _windowsExtensionService.ExecuteClickScript(session, action);
+            return WebDriverResult.Success();
+        }
+
+        private async Task<ActionResult> ExecuteWindowsScrollScript(Session session, ExecuteScriptRequest executeScriptRequest)
+        {
+            if (executeScriptRequest.Args.Count != 1)
+            {
+                throw WebDriverResponseException.InvalidArgument($"Expected an array of exactly 1 arguments for the windows: click script, but got {executeScriptRequest.Args.Count} arguments");
+            }
+            var action = JsonSerializer.Deserialize<WindowsScrollScript>(executeScriptRequest.Args[0], new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            if (action == null)
+            {
+                throw WebDriverResponseException.InvalidArgument("Action cannot be null");
+            }
+            await _windowsExtensionService.ExecuteScrollScript(session, action);
             return WebDriverResult.Success();
         }
 

--- a/src/FlaUI.WebDriver/Models/WindowsHoverScript.cs
+++ b/src/FlaUI.WebDriver/Models/WindowsHoverScript.cs
@@ -9,5 +9,6 @@
         public int? EndY { get; set; }
         public string? EndElementId { get; set; }
         public int? DurationMs { get; set; }
+        public string[]? ModifierKeys { get; set; }
     }
 }

--- a/src/FlaUI.WebDriver/Models/WindowsScrollScript.cs
+++ b/src/FlaUI.WebDriver/Models/WindowsScrollScript.cs
@@ -1,14 +1,12 @@
 ﻿namespace FlaUI.WebDriver.Models
 {
-    public class WindowsClickScript
+    public class WindowsScrollScript
     {
         public string? ElementId { get; set; }
         public int? X { get; set; }
         public int? Y { get; set; }
-        public string? Button { get; set; }
+        public int? DeltaX { get; set; }
+        public int? DeltaY { get; set; }
         public string[]? ModifierKeys { get; set; }
-        public int? DurationMs { get; set; }
-        public int? Times { get; set; }
-        public int? InterClickDelayMs { get; set; }
     }
 }

--- a/src/FlaUI.WebDriver/Services/IWindowsExtensionService.cs
+++ b/src/FlaUI.WebDriver/Services/IWindowsExtensionService.cs
@@ -5,6 +5,7 @@ namespace FlaUI.WebDriver.Services
     public interface IWindowsExtensionService
     {
         Task ExecuteClickScript(Session session, WindowsClickScript action);
+        Task ExecuteScrollScript(Session session, WindowsScrollScript action);
         Task ExecuteHoverScript(Session session, WindowsHoverScript action);
         Task ExecuteKeyScript(Session session, WindowsKeyScript action);
     }


### PR DESCRIPTION
Add the `windows: scroll` extension script for compatibility with appium-windows-driver.

Document the other Windows extension scripts and throw on unsupported options. Also fix the calculation of the mouse position by element ID and x and y coordinates.