### PR TITLE
Element SendKeys supports strings for different locales and non-US keaybords

### DIFF
--- a/src/FlaUI.WebDriver.UITests/ActionsTests.cs
+++ b/src/FlaUI.WebDriver.UITests/ActionsTests.cs
@@ -59,6 +59,34 @@ namespace FlaUI.WebDriver.UITests
         }
 
         [Test]
+        public void SendKeys_UnicodeCharacters_AreSupported()
+        {
+            var element = _driver.FindElement(ExtendedBy.AccessibilityId("TextBox"));
+            element.Clear();
+
+            var _sendString = "aA£Bb aA€Bb 4aF¤1rR";
+            element.SendKeys(_sendString);
+
+            System.Threading.Thread.Sleep(1000);
+            var refreshedElement = _driver.FindElement(ExtendedBy.AccessibilityId("TextBox"));
+            Assert.That(refreshedElement.Text, Is.EqualTo(_sendString));
+        }
+
+        [Test]
+        public void SendKeys_SpecialCharacters_AreSupported()
+        {
+            var element = _driver.FindElement(ExtendedBy.AccessibilityId("TextBox"));
+            element.Clear();
+
+            System.Threading.Thread.Sleep(1000);
+            string withSpecialCharacters = "!\"#Aa% &/(12)=?`!#%Bb^&*()+ >;:_^!\"#%&/(cC )=?Vv`!#%^&*(56)+ ><;:_*";
+            element.SendKeys(withSpecialCharacters);
+
+            var refreshedElement = _driver.FindElement(ExtendedBy.AccessibilityId("TextBox"));
+            Assert.That(refreshedElement.Text, Is.EqualTo(withSpecialCharacters));
+        }
+
+        [Test]
         public void ReleaseActions_Default_ReleasesKeys()
         {
             var element = _driver.FindElement(ExtendedBy.AccessibilityId("TextBox"));

--- a/src/FlaUI.WebDriver/Controllers/ElementController.cs
+++ b/src/FlaUI.WebDriver/Controllers/ElementController.cs
@@ -218,7 +218,7 @@ namespace FlaUI.WebDriver.Controllers
 
             try
             {
-                await _actionsDispatcher.DispatchActionsForString(session, inputId, source, elementSendKeysRequest.Text);
+                await _actionsDispatcher.DispatchActionsForStringUsingFlaUICore(session, inputId, source, elementSendKeysRequest.Text);
             }
             finally
             {

--- a/src/FlaUI.WebDriver/Services/ActionsDispatcher.cs
+++ b/src/FlaUI.WebDriver/Services/ActionsDispatcher.cs
@@ -420,5 +420,29 @@ namespace FlaUI.WebDriver.Services
                     throw WebDriverResponseException.UnsupportedOperation($"Pointer button {button} not supported");
             }
         }
+
+        private async Task<bool> KeyboardTypeWithTimeout(string text, int timeoutMilliseconds = 50)
+        {
+            var typeTask = Task.Run(() => Keyboard.Type(text));
+            var delayTask = Task.Delay(timeoutMilliseconds);
+            var completedTask = await Task.WhenAny(typeTask, delayTask);
+            if (completedTask == typeTask)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public async Task DispatchActionsForStringUsingFlaUICore(Session session, string inputId, KeyInputSource source, string text)
+        {
+            if (!await KeyboardTypeWithTimeout(text)) {
+                _logger.LogDebug("Keyboard typing error for {text}", text);
+                throw WebDriverResponseException.UnknownError($"Keyboard typing error for {text}");
+            }
+            await Task.Delay(50);
+        }
     }
 }

--- a/src/FlaUI.WebDriver/Services/IActionsDispatcher.cs
+++ b/src/FlaUI.WebDriver/Services/IActionsDispatcher.cs
@@ -5,5 +5,6 @@ namespace FlaUI.WebDriver.Services
     {
         Task DispatchAction(Session session, Action action);
         Task DispatchActionsForString(Session session, string inputId, KeyInputSource source, string text);
+        Task DispatchActionsForStringUsingFlaUICore(Session session, string inputId, KeyInputSource source, string text);
     }
 }


### PR DESCRIPTION
@jensakejohansson 
@hugoMeier
@aristotelos 
@Roemer 
@stevemonaco 
@bmarroquin 

The issue solves the issue as reported here:
https://github.com/FlaUI/FlaUI.WebDriver/issues/129

The updated implementation: Uses Flaui.Core.Input Keyboard.Type to handle the ElementSendKeys request.
The FlaUI.Core already handles many more characters in strings than the WebDriver does not.

It is possible that ElementSendKeys should handle many more string variants containing for example Selenium Keys.XXX but

* this is not handled in the original WebDriver implementation 
* it is handled by WebDriver PerformActions anyways

Added also some UITests that confirm the updated functionality